### PR TITLE
The Wave surface: first-class orchestration drivers (docs/31)

### DIFF
--- a/docs/31-wave-driver-ax.md
+++ b/docs/31-wave-driver-ax.md
@@ -36,18 +36,23 @@ roster plus objectives — and the lifecycle semantics above are baton's own, no
 
 ```js
 const wave = await baton.waves.start({
-  members: [{ role, exact?, harness?, model?, effort?, scope, objective }],
-  verification?,              // optional deployment verification override
+  members: [{ role, exact?, harness?, model?, effort?, scope, objective, report? }],
   approve? = true,            // explicit distinct approval, receipted per member
+  repoRoot?,                  // optional: enables the refs/baton/results pin fallback AND the
+                              // filesystem bare-directory scope check
 });
 wave.runs                     // role -> BatonRun
 await wave.send(role, message, { delivery: 'now' });
 await wave.progress()         // per-member: phase, attention, elapsed, stoppable
 await wave.stopMember(role, { reason, timeoutMs? })   // retry-until-stoppable inside
 const outcomes = await wave.settle({ timeoutMs });    // per-member outcome, always produced
-const stop = await wave.close({ reason });            // per-member stops, zero-residue summary
+const stop = await wave.close({ reason });            // per-member stops, residue summary
 const record = wave.evidence();                       // structured wave record
 ```
+
+`report` is the member's own report path used only by the pin fallback's path-existence
+disambiguation. `verification` is deployment-level (openBaton `advanced.verification`), never a
+wave option.
 
 Baked semantics (each numbered to its failure mode):
 
@@ -60,16 +65,23 @@ Baked semantics (each numbered to its failure mode):
    changes nothing about the others' lifecycles.
 4. `work_completed` counts as success-terminal for outcome purposes; `selection_required`
    surfaces as attention, never as completion.
-5. Scopes are validated as globs at admission: a bare directory path (no glob magic, existing
-   directory semantics) fails `wave_scope_invalid` with the corrective form (`dir/**`).
-6. `settle` materializes each member's preserved result from the result section first, then
+5. Scopes are validated as globs at admission: a bare directory fails `wave_scope_invalid`
+   with the corrective form (`dir/**`). With `repoRoot` the filesystem decides; otherwise a
+   glob-magic + basename-dot heuristic decides, and a non-existent dotless path is treated as an
+   intended directory.
+6. `settle` materializes each member's preserved result from the result section first
+   (`run.inspect{depth:'section'}` — `section` is top-level, there is no `.view` wrapper), then
    from `refs/baton/results/*` **only** with git path-existence disambiguation and a start-time
-   window, never by newest-pin guessing.
-7. `stopMember` retries `application_action_scope_mismatch` /
-   `application_workflow_member_stop_unavailable` until the member's attempt is dispatched or a
-   bounded deadline, then reports honestly.
+   window, never by newest-pin guessing. The fallback needs both `repoRoot` and the member's
+   `report`.
+7. Waves compose plain runs today, so selective stop means: `stop_member` when the member run
+   advertises it (workflow members, retried while the attempt's `taskId` is unassigned — the
+   receipted dispatch race), else `run.stop` for plain members. The branch taken is recorded.
 8. `settle` always produces an outcome for every member — including after its own timeout —
-   and `close` returns a zero-residue summary (or the exact remaining count per member).
+   and `close` reports residue per member from the RunView `resources` block
+   (`ownedCount`/`cleanupState`); a stop view without it is reported as `residueUnknown`, never
+   coalesced to zero. Pumps never outlive the call that armed them: `settle` and `close` drain
+   outstanding `run.complete()` promises with a bounded grace before returning.
 
 ## Program-IR alignment (not a second scheduler)
 

--- a/docs/31-wave-driver-ax.md
+++ b/docs/31-wave-driver-ax.md
@@ -77,6 +77,9 @@ Baked semantics (each numbered to its failure mode):
 7. Waves compose plain runs today, so selective stop means: `stop_member` when the member run
    advertises it (workflow members, retried while the attempt's `taskId` is unassigned — the
    receipted dispatch race), else `run.stop` for plain members. The branch taken is recorded.
+   The workflow-member dispatch-race retry is currently **unpinned**: no wave row can build a
+   workflow member yet (nested orchestration is issue #12), and docs/31 does not claim coverage
+   the surface cannot reach.
 8. `settle` always produces an outcome for every member — including after its own timeout —
    and `close` reports residue per member from the RunView `resources` block
    (`ownedCount`/`cleanupState`); a stop view without it is reported as `residueUnknown`, never

--- a/docs/31-wave-driver-ax.md
+++ b/docs/31-wave-driver-ax.md
@@ -1,0 +1,88 @@
+# Doc 31 — the Wave surface: first-class orchestration drivers (AX remediation)
+
+*Status: design note, implemented with `impl/src/wave.mjs` and `impl/test/wave-driver-red.test.mjs`.
+Addresses the agentic-experience defect that every orchestration wave cost a bespoke ~300-line
+driver plus hours of orchestrator-side bugs. Issue-10 AX scope; Program-IR (93B/E) aligned.*
+
+## Problem (receipted, 2026-07-20/21 dogfood)
+
+An orchestrator driving N concurrent workers through `openBaton`/`BatonClient` had to hand-write,
+every time: per-member start, explicit approval, pump re-arming, terminal detection, attention
+surfacing, result materialization, steering, selective stop, and zero-residue close. The failure
+modes were all self-inflicted and all avoidable:
+
+1. **Passive-status stall** — polling `run.status()` never approves a Plan; a wave sat at
+   `awaiting_plan_approval` for 90 minutes.
+2. **Pump-as-terminal kill** — `run.complete()` returns on RunView quiescence; treating its
+   return as terminal made a driver SIGTERM a healthy worker mid-read.
+3. **Fail-fast cascade** — `startMany`'s group semantics resolved early on one crashed seat, and
+   the bespoke materialize-then-stop order killed two healthy reviewers.
+4. **Terminal taxonomy** — `work_completed` (non-terminal resting state) vs `completed` vs
+   `selection_required` vs `failed` vs `cancelled` was guessed wrong repeatedly.
+5. **Glob-scope misuse** — a bare directory scope matches only itself; the trust gate correctly
+   rejected the capture (`inScopeChangedPathCount: 2` of 5).
+6. **Pin-fallback ambiguity** — the newest `refs/baton/results/*` pin belonged to a sibling run;
+   materialization needed path-existence disambiguation.
+7. **`stopMember` dispatch race** — `stoppableRoles` requires `taskId !== null`; a fixed-time
+   stop missed the dispatch window twice.
+8. **Watchdog skipping outcomes** — a watchdog abort produced zero materialized results even
+   though two workers had finished.
+
+## Remediation
+
+One first-class orchestrator-side surface over any Baton command port (embedded `bindBaton`,
+resident `bindBatonPort`, or an authenticated web client port), so a wave is *data* — a member
+roster plus objectives — and the lifecycle semantics above are baton's own, not the caller's:
+
+```js
+const wave = await baton.waves.start({
+  members: [{ role, exact?, harness?, model?, effort?, scope, objective }],
+  verification?,              // optional deployment verification override
+  approve? = true,            // explicit distinct approval, receipted per member
+});
+wave.runs                     // role -> BatonRun
+await wave.send(role, message, { delivery: 'now' });
+await wave.progress()         // per-member: phase, attention, elapsed, stoppable
+await wave.stopMember(role, { reason, timeoutMs? })   // retry-until-stoppable inside
+const outcomes = await wave.settle({ timeoutMs });    // per-member outcome, always produced
+const stop = await wave.close({ reason });            // per-member stops, zero-residue summary
+const record = wave.evidence();                       // structured wave record
+```
+
+Baked semantics (each numbered to its failure mode):
+
+1. Every member is started individually and **explicitly approved** (unless `approve:false`),
+   so nothing ever waits on a silent authority gate.
+2. The surface never treats `run.complete()`'s return as terminal; settle's terminal predicate
+   is `outline.terminal === true` or the closed terminal-phase set
+   `{stopped, failed, cancelled, completed}`.
+3. Per-member isolation is unconditional: one member's crash, refusal, or terminal failure
+   changes nothing about the others' lifecycles.
+4. `work_completed` counts as success-terminal for outcome purposes; `selection_required`
+   surfaces as attention, never as completion.
+5. Scopes are validated as globs at admission: a bare directory path (no glob magic, existing
+   directory semantics) fails `wave_scope_invalid` with the corrective form (`dir/**`).
+6. `settle` materializes each member's preserved result from the result section first, then
+   from `refs/baton/results/*` **only** with git path-existence disambiguation and a start-time
+   window, never by newest-pin guessing.
+7. `stopMember` retries `application_action_scope_mismatch` /
+   `application_workflow_member_stop_unavailable` until the member's attempt is dispatched or a
+   bounded deadline, then reports honestly.
+8. `settle` always produces an outcome for every member — including after its own timeout —
+   and `close` returns a zero-residue summary (or the exact remaining count per member).
+
+## Program-IR alignment (not a second scheduler)
+
+The Wave is deliberately the runtime shadow of the §93.24 93E template lowerings: members ↔
+parallel branches/calls, `settle` ↔ join, outcome materialization ↔ collect/select,
+`stopMember` ↔ selective member stop, `wave.evidence()` ↔ the Program trace. When Program v1
+runtime lands, `baton.waves` becomes a lowering target, not a replacement: it holds no durable
+state of its own, no event-log authority, and no scheduling loop beyond per-member pumping.
+
+## Non-goals
+
+- No durability of the Wave itself (orchestrator-side; Program v1 owns durable composition).
+- No resident-server-hosted waves yet (the command port is transport-agnostic, so the resident
+  path works through `bindBatonPort` without new server code).
+- No worker-side access (nested orchestration is issue #12).
+- No new event kinds, authority, or ledger writes beyond the ordinary Run commands it composes.

--- a/docs/reference/evidence/wave-driver-ax-live-2026-07-21/acceptance-review.md
+++ b/docs/reference/evidence/wave-driver-ax-live-2026-07-21/acceptance-review.md
@@ -1,0 +1,143 @@
+# Wave driver surface (docs/31) — acceptance review
+
+Scope: `docs/31-wave-driver-ax.md`, `impl/src/wave.mjs`, `impl/test/wave-driver-red.test.mjs`,
+the `baton.waves` getter and `runs.*` contracts in `impl/src/application-client.mjs`.
+Deployment verification (pinned suite) executed:
+
+```
+node --test impl/test/wave-driver-red.test.mjs   →   exit 0  (9/9 pass)
+```
+
+The contract is GREEN. This review nonetheless rejects acceptance: two of the eight baked
+semantics (docs/31 #6 materialization, docs/31 #8 residue truth) are enforced only *vacuously* —
+the code reads response fields that the Baton command port never emits, so the guarantee silently
+degrades and the W rows that claim to pin it pass without exercising the real behavior. The
+task's own done-condition — "Baton preserves exact route, result, and cleanup truth" — is exactly
+what fails: **result truth and cleanup truth are both unenforced.**
+
+## Verdict
+
+REJECT (green suite, non-genuine pins). Route/approval/isolation/attention semantics (#1–#5, #7
+for the plain-run path) are genuinely enforced and genuinely pinned. But:
+
+- **docs/31 #6 "materializes from the result section first" is dead code.** `materialize`
+  (`wave.mjs:184-186`) reads `results?.view?.section?.items?.[0]?.value`, but the core
+  `run.inspect{depth:'section'}` response has `section` at the **top level** with no `.view`
+  wrapper (`application.mjs:9381-9388`; the CLI mirror confirms `result.section`, not
+  `result.view.section`, at `application-cli.mjs:927`). `results.view` is always `undefined`, so
+  the primary path always yields `undefined`, `RESULT_SHA.test('')` is false, and **every**
+  materialization silently falls through to the `refs/baton/results/*` git fallback. The correct
+  address is `results?.section?.items?.[0]?.value.sha` (the result item's `value` is
+  `clone(view.result) = { sha, ref }`, `application.mjs:8931/8944`), so this is a one-token
+  (`.view.`) regression that disables the documented "result section first" behavior entirely.
+
+- **docs/31 #8 "the exact remaining count per member" is structurally always 0.** `close`
+  (`wave.mjs:262`) computes `stop.ownership?.remainingCount ?? 0`. The `run.stop` RunView carries
+  residue at `stop.stop.receipt.remainingCount` (proven by `application.mjs:4666`
+  `runStop?.receipt?.remainingCount`, `application.mjs:1373`, and `web-operator.mjs:145`
+  `view.stop.receipt.remainingCount`). The view's `ownership` field is
+  `{ workers, workerIds, closed }` / `{ runAuthorityReleased }` (`application.mjs:4695`,
+  `3948`, `10296`) and has **no** `remainingCount`. So `stop.ownership?.remainingCount` is
+  perpetually `undefined → 0`. `close.remainingCount` is hardcoded-to-zero for every successful
+  stop; the genuine residue signal (which `close` even *stores* as `stop: stopped.stop`) is never
+  read. Cleanup truth is not surfaced.
+
+Because of these two field-path defects, the following W-row assertions are **vacuous** (they pass
+regardless of the behavior they name):
+
+- `remainingCount === 0` in **W2, W3, W6, W8** — always 0 by construction; would pass even with
+  live residue. W8's title claims "ownership receipts" but never asserts any stop record carries
+  one.
+- **W7** genuinely pins the pin-disambiguation fallback (path-probing + used-sha exclusion), but
+  it exercises only the fallback; the documented **"result section first"** path is never
+  covered by any row (it is dead), so failure mode #6's *primary* remedy is unpinned.
+- **W6**'s `stop.admitted === true || stop.stopped === true` masks that waves only ever create
+  plain runs (`baton.runs.start`), which never advertise a `stop_member` action; `act('stop_member')`
+  always throws `application_action_unavailable`, so the retry-on-`application_action_scope_mismatch` /
+  `application_workflow_member_stop_unavailable` loop and the `admitted:true` branch
+  (`wave.mjs:163-178`) are **unreachable** in the wave surface. docs/31 #7's dispatch-race retry is
+  claimed but inert; W6 only ever proves the `run.stop` fallback.
+
+## P0-P1 findings
+
+**P1-A — Result materialization never uses the result section (docs/31 #6 claimed, not enforced).**
+`wave.mjs:185` `results?.view?.section` reads a non-existent wrapper; `run.inspect{depth:'section'}`
+returns `section` at top level (`application.mjs:9381-9388`). The primary "result section first"
+path is dead; materialization silently relies on the git-pin fallback, which needs two
+**undocumented** inputs absent from the docs/31 public surface: the wave-level `repoRoot`
+(`wave.mjs:88`) and the member-level `report` (`wave.mjs:181-206`). Under the *documented* API
+(`baton.waves.start({ members:[{role,exact?,harness?,model?,effort?,scope,objective}], verification?,
+approve? })`) neither exists, so `settle` returns `resultSha: null` for every member — no result is
+ever materialized. The whole suite only materializes because the test `member()` helper injects
+`report:` and every `createWave` call injects `repoRoot:`. Result truth is not preserved through
+the advertised surface.
+
+**P1-B — Zero-residue close reads the wrong receipt; remaining count is always 0 (docs/31 #8
+claimed, not enforced).** `wave.mjs:262` reads `stop.ownership?.remainingCount`; residue lives at
+`stop.stop.receipt.remainingCount`. `close.remainingCount` cannot ever report a non-zero residue
+for a successful stop, so "the exact remaining count per member" is never honest, and a stop that
+leaves owned workers behind is reported as zero-residue. Missing/partial ownership receipts are
+also swallowed by the same `?? 0`. Cleanup truth is not preserved.
+
+**P1-C — docs/31 #7 stopMember retry path is inert for waves.** Waves compose only plain runs, so
+the scope-mismatch retry loop and the `admitted` branch never execute; only the
+`application_action_unavailable → run.stop` fallback (`wave.mjs:169-172`) runs. The receipted
+failure mode (workflow-member dispatch race, `stoppableRoles` requiring `taskId !== null`) is not
+reachable or exercised here. Either wire waves to real workflow members, or scope docs/31 #7 to the
+plain-run `run.stop` fallback it actually delivers, so the claim matches the surface.
+
+**P2-D — Glob admission does not enforce "existing directory semantics" (docs/31 #5).**
+`validateMember` (`wave.mjs:33-44`) distinguishes file from directory by a basename `.`-heuristic,
+never touching the filesystem. A dotted directory name (`assets/v1.2`) passes even as a bare
+directory; a non-existent path (`nowhere`) is rejected as if it existed. W5 only probes `reports`
+(no dot), so the heuristic's false-accept/false-reject corners are unpinned. Behavior is
+conservative, but the doc's "existing directory semantics" wording is not what the code does.
+
+**P2-E — Pump leak on settle timeout.** `armPump` (`wave.mjs:142-149`) fires
+`run.complete()` fire-and-forget and only clears its `pumps` flag on resolution. When `settle`
+returns on its own timeout (W3: beta `delayMs 60_000`, timeout 2_000), the in-flight
+`run.complete()` keeps driving the run in the background after `settle` has returned, and races the
+subsequent `close`→`run.stop`. Rejections are absorbed (no unhandled rejection), so it is not
+fatal, but the "no scheduling loop beyond per-member pumping / holds no durable state" claim is
+weakened by orphaned pumps that outlive the wave call that armed them. No row asserts pump
+quiescence.
+
+Notes that are NOT defects: the `baton.waves` getter (`application-client.mjs:1484-1486`) is
+sound — the arrow captures the getter's `this` (the frozen `BatonClient`), so destructuring
+`const { start } = client.waves` keeps the binding; the returned object is frozen. Per-member
+isolation (#3), explicit approval (#1, with W1's `approve:false` parked control proving the gate),
+`work_completed`/`selection_required` taxonomy (#4 via `attentionFrom`/settle), and the
+`{stopped,failed,cancelled,completed}` terminal set (#2, `run.complete()`'s return is correctly
+discarded) are genuinely enforced. `settle` always producing an outcome (#8 first clause) is
+genuine and genuinely pinned by W3.
+
+## Required corrections
+
+1. **P1-A:** Fix `wave.mjs:185` to `results?.section?.items?.[0]?.value` (drop the `.view.`
+   wrapper) so "result section first" actually runs; then add a W row that asserts a member's
+   `resultSha` is produced from the result section **without** `repoRoot`/`report` (i.e. the
+   documented surface). Either document `repoRoot`/`report`/`verification` in docs/31's API block
+   and wire `verification` (currently accepted in the doc signature but never read by `createWave`),
+   or remove them from the doc so the surface and the claim agree.
+
+2. **P1-B:** Fix `wave.mjs:262` to read `stop.stop?.receipt?.remainingCount` (with an explicit
+   unknown/attention path when the receipt is absent, rather than coalescing missing receipts to
+   0). Add a W row that drives a non-zero residue (or a stop whose receipt is missing) and asserts
+   `close.remainingCount` reflects it and that each `stops[i]` carries an ownership/receipt — so
+   the W2/W3/W6/W8 `remainingCount === 0` assertions stop being vacuous.
+
+3. **P1-C:** Reconcile docs/31 #7 with reality: either exercise a workflow-member wave so the
+   `stop_member` retry/`admitted` branch is reachable and pin it, or narrow the doc to the
+   plain-run `run.stop` fallback the wave actually performs, and change W6 to assert the specific
+   branch taken instead of `admitted || stopped`.
+
+4. **P2-D:** Either perform a real filesystem existing-directory check in `validateMember`, or
+   reword docs/31 #5 to describe the glob-magic + basename heuristic that is actually implemented;
+   add W-row coverage for a dotted-directory and a non-existent path.
+
+5. **P2-E:** Track and drain pumps on `settle` return/timeout (await or abort the outstanding
+   `run.complete()` promises before returning), and assert pump quiescence in the timeout row.
+
+6. Re-run the pinned suite after corrections; the contract
+   (`node --test impl/test/wave-driver-red.test.mjs`, exit 0) must stay green **and** the newly
+   added assertions must be non-vacuous (fail if the field-path bugs are reintroduced).

--- a/docs/reference/evidence/wave-driver-ax-live-2026-07-21/run-acceptance.mjs
+++ b/docs/reference/evidence/wave-driver-ax-live-2026-07-21/run-acceptance.mjs
@@ -1,0 +1,113 @@
+import { rmSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { openBaton } from '../../../../impl/src/index.mjs';
+
+const evidenceDir = dirname(fileURLToPath(import.meta.url));
+const repo = resolve(evidenceDir, '../../../..');
+const relativeRoot = 'docs/reference/evidence/wave-driver-ax-live-2026-07-21';
+const reportPath = `${relativeRoot}/acceptance-review.md`;
+const VERIFY = Object.freeze({
+  command: 'node',
+  arguments: ['--test', 'impl/test/wave-driver-red.test.mjs'],
+});
+const exact = { harness: 'claude-code', model: 'claude-opus-4-8', effort: 'high' };
+
+const baton = await openBaton({ repo, advanced: { routes: [exact], verification: VERIFY } });
+const log = (line) => console.log(`[wave-acc ${new Date().toISOString()}] ${line}`);
+let run = null;
+let failure = null;
+const startedAt = Date.now();
+try {
+  const readiness = await baton.doctor();
+  const ready = readiness.routes.find((candidate) => (
+    candidate.harness === exact.harness && candidate.model === exact.model && candidate.effort === exact.effort
+  ));
+  if (ready?.state !== 'ready') {
+    throw Object.assign(new Error(ready?.summary ?? 'route unavailable'), { code: ready?.code ?? 'route_unavailable' });
+  }
+  rmSync(resolve(repo, reportPath), { force: true });
+  run = await baton.runs.start([
+    'Act as the acceptance reviewer for the Wave driver surface (PR branch wave-driver-ax).',
+    'READ-ONLY: never modify any file except the report; never write scratch files (including',
+    '/tmp). Read: docs/31-wave-driver-ax.md, impl/src/wave.mjs, impl/test/wave-driver-red.test.mjs,',
+    'the baton.waves getter in impl/src/application-client.mjs, and the client contracts in',
+    'impl/src/application-client.mjs (runs.start/approve/send/stopMember analogues). Attack:',
+    '(1) every docs/31 baked semantic actually enforced in code — find one that is only claimed;',
+    '(2) terminal/attention logic corners (attentionFrom synthesis, terminalFrom set); (3) settle',
+    'race/pump leaks (pumps map lifecycle, re-arm on terminal, timeout paths); (4) materialize',
+    'fallback pin disambiguation correctness (window, used-sha exclusion, path probing); (5)',
+    'stopMember fallback for plain runs vs workflow members; (6) close remainingCount honesty',
+    '(missing ownership receipts); (7) the waves getter freeze/this-binding; (8) any concurrency',
+    'hazard across concurrent settle/progress/stopMember calls. Run the pinned suite. Report',
+    'whether the W rows genuinely pin each failure mode or any is vacuous.',
+    `Write only ${reportPath} with EXACTLY these headings:`,
+    '## Verdict',
+    '## P0-P1 findings',
+    '## Required corrections',
+    'Do not invoke nested Baton. One shell command per call. Do not mutate credentials, harness',
+    'installations, global configuration, or the main checkout. Finish when the report is written.',
+  ].join(' '), { exact, scope: [reportPath] });
+  log(`acceptance reviewer started as ${run.id}`);
+  await run.approve();
+  const pumpArm = { active: false };
+  const armPump = () => {
+    if (pumpArm.active) return;
+    pumpArm.active = true;
+    run.complete().then(
+      (view) => { pumpArm.active = false; log(`pump returned phase=${view?.outline?.phase ?? view?.phase ?? '?'}`); },
+      () => { pumpArm.active = false; },
+    );
+  };
+  armPump();
+  let done = false;
+  while (!done && Date.now() - startedAt < 45 * 60 * 1000) {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20000));
+    const view = await run.status();
+    const outline = view?.view ?? view;
+    const phase = outline?.phase ?? '?';
+    log(`progress ${Math.round((Date.now() - startedAt) / 1000)}s phase=${phase}`);
+    if (outline?.terminal === true || ['stopped', 'failed', 'cancelled', 'completed', 'work_completed'].includes(phase)) {
+      done = true;
+    } else {
+      armPump();
+    }
+  }
+  const results = await run.inspect({ depth: 'section', section: 'result' });
+  const value = results?.view?.section?.items?.[0]?.value;
+  let sha = /^[a-f0-9]{40,64}$/u.test(value?.sha ?? '') ? value.sha : null;
+  if (!sha) {
+    const { execFileSync } = await import('node:child_process');
+    const pins = execFileSync('/usr/bin/git', ['for-each-ref', 'refs/baton/results/', '--format=%(objectname) %(committerdate:unix)'], { cwd: repo, encoding: 'utf8' })
+      .trim().split('\n').filter(Boolean)
+      .map((row) => ({ sha: row.split(' ')[0], at: Number(row.split(' ')[1]) }))
+      .sort((a, b) => b.at - a.at);
+    for (const pin of pins) {
+      try {
+        execFileSync('/usr/bin/git', ['cat-file', '-e', `${pin.sha}:${reportPath}`], { cwd: repo, stdio: 'ignore' });
+        sha = pin.sha;
+        break;
+      } catch { /* not in pin */ }
+    }
+  }
+  if (sha) {
+    const { execFileSync } = await import('node:child_process');
+    const body = execFileSync('/usr/bin/git', ['show', `${sha}:${reportPath}`], { cwd: repo, encoding: 'utf8', maxBuffer: 512 * 1024 });
+    writeFileSync(resolve(repo, reportPath), body);
+    log(`report materialized at ${sha}`);
+  } else {
+    log('no preserved result');
+  }
+} catch (error) {
+  failure = error;
+  console.error(failure);
+} finally {
+  if (run) {
+    try { await run.stop('wave acceptance settled.'); } catch { /* best effort */ }
+  }
+  try {
+    if (typeof baton.close === 'function') await baton.close();
+  } catch { /* best effort */ }
+}
+process.exitCode = failure ? 1 : 0;

--- a/impl/src/application-client.mjs
+++ b/impl/src/application-client.mjs
@@ -1,6 +1,7 @@
 import { contextProgramIsPure } from './context-authority.mjs';
 import { normalizeContextProgram } from './context-program.mjs';
 import { APPLICATION_SEMANTIC_REGISTRY } from './application-semantics.mjs';
+import { createWave } from './wave.mjs';
 
 function clientError(message, code = 'application_client_invalid') {
   return Object.assign(new Error(message), { code });
@@ -1478,6 +1479,10 @@ export class BatonClient {
     this.runs = new BatonRuns(application);
     this.#application = application;
     Object.freeze(this);
+  }
+
+  get waves() {
+    return Object.freeze({ start: (options = {}) => createWave(this, options) });
   }
 
   help(topic = 'application', depth = 'outline') {

--- a/impl/src/index.mjs
+++ b/impl/src/index.mjs
@@ -182,6 +182,7 @@ export {
   BatonRun, BatonRunContext, BatonRunGroup, BatonRuns, BatonWorkstream, BatonWorkstreams,
   bindBaton, bindBatonPort,
 } from './application-client.mjs';
+export { createWave } from './wave.mjs';
 export { BatonWebHost, SignalLifecycleOwner } from './application-host.mjs';
 export { HttpsHmacAdvisoryFeedSource, signHmacAdvisoryPollPageForTest } from './https-hmac-advisory-feed.mjs';
 export { Ed25519AdvisoryWebhookSource, HmacAdvisoryWebhookSource, signEd25519AdvisoryWebhookForTest, signHmacAdvisoryWebhookForTest } from './hmac-advisory-webhook.mjs';

--- a/impl/src/wave.mjs
+++ b/impl/src/wave.mjs
@@ -1,0 +1,287 @@
+// Wave driver surface (docs/31): first-class orchestration waves over any Baton client facade.
+// A wave is data — a member roster plus objectives — and every lifecycle semantic is Baton's
+// own: explicit per-member approval, per-member isolation, re-armed drive pumps (never a
+// terminal signal), the closed terminal-phase set, attention surfacing, result materialization
+// with path-existence pin disambiguation, selective member stop, and zero-residue close.
+// Program-IR aligned: members ↔ parallel branches, settle ↔ join, materialization ↔ collect,
+// stopMember ↔ selective stop, evidence() ↔ the wave trace. It holds no durable state of its own.
+
+const TERMINAL_PHASES = new Set(['stopped', 'failed', 'cancelled', 'completed']);
+const SUCCESS_RESTING = 'work_completed';
+const RESULT_SHA = /^[a-f0-9]{40,64}$/u;
+const GLOB_MAGIC = /[*?[\]{}!+@]/u;
+const POLL_MS = 50;
+
+function waveError(message, code = 'wave_invalid') {
+  return Object.assign(new TypeError(message), { code });
+}
+
+function validateMember(member, index) {
+  if (!member || typeof member !== 'object' || Array.isArray(member)) {
+    throw waveError(`wave member[${index}] must be an object`);
+  }
+  const role = member.role;
+  if (typeof role !== 'string' || role.trim().length === 0) throw waveError(`wave member[${index}] role is invalid`);
+  if (typeof member.objective !== 'string' || member.objective.trim().length === 0) {
+    throw waveError(`wave member ${role} objective is invalid`);
+  }
+  if (!Array.isArray(member.scope) || member.scope.length === 0 || member.scope.length > 64
+    || member.scope.some((entry) => typeof entry !== 'string' || entry.trim().length === 0)
+    || new Set(member.scope).size !== member.scope.length) {
+    throw waveError(`wave member ${role} scope is invalid`, 'wave_scope_invalid');
+  }
+  for (const entry of member.scope) {
+    if (!GLOB_MAGIC.test(entry)) {
+      const basename = entry.replace(/\/+$/u, '').split('/').pop() ?? '';
+      if (!basename.includes('.')) {
+        throw waveError(
+          `wave member ${role} scope entry "${entry}" names a bare directory, which matches only `
+          + `itself under glob scope semantics; use "${entry.replace(/\/+$/u, '')}/**" instead`,
+          'wave_scope_invalid',
+        );
+      }
+    }
+  }
+  if (member.exact !== undefined) {
+    const exact = member.exact;
+    if (!exact || typeof exact !== 'object' || Array.isArray(exact)
+      || ['harness', 'model', 'effort'].some((field) => typeof exact[field] !== 'string' || exact[field].length === 0)
+      || Object.keys(exact).some((field) => !['harness', 'model', 'effort'].includes(field))) {
+      throw waveError(`wave member ${role} exact route is invalid`);
+    }
+  }
+  const selector = { harness: member.harness, model: member.model, effort: member.effort };
+  if (member.exact === undefined
+    && [selector.harness, selector.model, selector.effort].some((value) => value !== undefined)
+    && (selector.model === undefined || selector.effort === undefined)) {
+    throw waveError(`wave member ${role} manual routing requires model and effort together`);
+  }
+  return Object.freeze({ ...member, role: role.trim() });
+}
+
+function terminalFrom(outline) {
+  return outline?.terminal === true || TERMINAL_PHASES.has(outline?.phase);
+}
+
+function attentionFrom(outline) {
+  const attention = outline?.attention;
+  if (Array.isArray(attention) && attention.length === 0) return null;
+  if (attention === 'clear') return null;
+  if (attention !== null && attention !== undefined) return attention;
+  const phase = outline?.phase;
+  if (phase === 'awaiting_plan_approval') return 'blocked_interaction:approve_plan';
+  if (phase === 'selection_required') return 'blocked_interaction:select_candidate';
+  if (phase === 'input_required') return 'blocked_interaction:answer_required';
+  return null;
+}
+
+export async function createWave(baton, options = {}) {
+  if (!baton || !baton.runs || typeof baton.runs.start !== 'function') {
+    throw waveError('createWave requires a Baton client facade with runs.start');
+  }
+  if (!options || typeof options !== 'object' || Array.isArray(options)) throw waveError('wave options are invalid');
+  const membersInput = options.members;
+  if (!Array.isArray(membersInput) || membersInput.length === 0 || membersInput.length > 64) {
+    throw waveError('wave members must be one bounded non-empty array');
+  }
+  const approve = options.approve !== false;
+  const repoRoot = typeof options.repoRoot === 'string' && options.repoRoot.length > 0 ? options.repoRoot : null;
+  const members = membersInput.map(validateMember);
+  if (new Set(members.map(({ role }) => role)).size !== members.length) {
+    throw waveError('wave member roles contain duplicates');
+  }
+
+  const state = {
+    startedAt: Date.now(),
+    members: new Map(),
+    outcomes: [],
+    progress: [],
+    steering: [],
+    stops: [],
+  };
+
+  // Start members individually and explicitly approve each — nothing parks on a silent
+  // authority gate, and one member's start failure never aborts the others.
+  for (const member of members) {
+    const entry = { member, run: null, startError: null };
+    try {
+      const route = member.exact
+        ? { exact: member.exact }
+        : { harness: member.harness, model: member.model, effort: member.effort };
+      entry.run = await baton.runs.start(member.objective, { ...route, scope: [...member.scope] });
+      if (approve) await entry.run.approve();
+    } catch (error) {
+      entry.startError = { code: error?.code ?? null, message: String(error?.message ?? error) };
+    }
+    state.members.set(member.role, entry);
+  }
+
+  async function progress() {
+    const members = [];
+    for (const [role, entry] of state.members) {
+      if (!entry.run) {
+        members.push({ role, phase: 'start_failed', terminal: true, attention: null, error: entry.startError });
+        continue;
+      }
+      const view = await entry.run.status();
+      const outline = view?.view ?? view ?? {};
+      members.push({
+        role,
+        phase: outline.phase ?? null,
+        terminal: terminalFrom(outline),
+        attention: attentionFrom(outline),
+        elapsedMs: Date.now() - state.startedAt,
+      });
+    }
+    const snapshot = { elapsedMs: Date.now() - state.startedAt, members };
+    state.progress.push({ at: new Date().toISOString(), members: members.map(({ role, phase }) => ({ role, phase })) });
+    return snapshot;
+  }
+
+  const pumps = new Map();
+  function armPump(entry) {
+    if (!entry.run || pumps.get(entry.member.role) === true) return;
+    pumps.set(entry.member.role, true);
+    entry.run.complete().then(
+      () => { pumps.set(entry.member.role, false); },
+      () => { pumps.set(entry.member.role, false); },
+    );
+  }
+
+  async function send(role, message, options = {}) {
+    const entry = state.members.get(role);
+    if (!entry?.run) throw waveError(`wave member ${role} is not running`);
+    const receipt = await entry.run.send(message, options);
+    state.steering.push({ role, at: new Date().toISOString(), state: 'sent' });
+    return receipt;
+  }
+
+  async function stopMember(role, { reason = 'Wave selective member stop.', timeoutMs = 5_000 } = {}) {
+    const entry = state.members.get(role);
+    if (!entry?.run) throw waveError(`wave member ${role} is not running`);
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      try {
+        await entry.run.act('stop_member', { role, reason });
+        state.stops.push({ role, via: 'stop_member', at: new Date().toISOString() });
+        return { admitted: true, role };
+      } catch (error) {
+        if (error?.code === 'application_action_unavailable') {
+          const receipt = await entry.run.stop(reason);
+          state.stops.push({ role, via: 'run.stop', receipt: receipt?.stop ?? null, ownership: receipt?.ownership ?? null });
+          return { stopped: true, role, receipt };
+        }
+        if (!['application_action_scope_mismatch', 'application_workflow_member_stop_unavailable'].includes(error?.code)
+          || Date.now() > deadline) throw error;
+        await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+      }
+    }
+  }
+
+  async function materialize(entry) {
+    const { member, run } = entry;
+    try {
+      const results = await run.inspect({ depth: 'section', section: 'result' });
+      const value = results?.view?.section?.items?.[0]?.value;
+      if (RESULT_SHA.test(value?.sha ?? '')) return value.sha;
+    } catch { /* section projection can be empty post-stop */ }
+    if (!repoRoot || !member.report) return null;
+    let pins;
+    try {
+      pins = (await import('node:child_process')).execFileSync('/usr/bin/git', ['for-each-ref', 'refs/baton/results/', '--format=%(objectname) %(committerdate:unix)'], { cwd: repoRoot, encoding: 'utf8' })
+        .trim().split('\n').filter(Boolean)
+        .map((row) => ({ sha: row.split(' ')[0], at: Number(row.split(' ')[1]) }))
+        .filter((pin) => pin.at * 1000 >= state.startedAt - 60_000)
+        .sort((left, right) => right.at - left.at);
+    } catch { return null; }
+    const used = state.outcomes.map((outcome) => outcome.resultSha).filter(Boolean);
+    const { execFileSync } = await import('node:child_process');
+    for (const pin of pins) {
+      if (used.includes(pin.sha)) continue;
+      try {
+        execFileSync('/usr/bin/git', ['cat-file', '-e', `${pin.sha}:${member.report}`], { cwd: repoRoot, stdio: 'ignore' });
+        return pin.sha;
+      } catch { /* pin does not carry this report path */ }
+    }
+    return null;
+  }
+
+  async function settle({ timeoutMs = 60_000 } = {}) {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) throw waveError('wave settle timeoutMs is invalid');
+    const deadline = Date.now() + timeoutMs;
+    const settled = new Set([...state.members.keys()].filter((role) => !state.members.get(role).run));
+    while (settled.size < state.members.size && Date.now() < deadline) {
+      for (const [role, entry] of state.members) {
+        if (settled.has(role) || !entry.run) continue;
+        const view = await entry.run.status();
+        const outline = view?.view ?? view;
+        if (terminalFrom(outline) || outline?.phase === SUCCESS_RESTING) {
+          settled.add(role);
+        } else {
+          armPump(entry);
+        }
+      }
+      if (settled.size < state.members.size) {
+        await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+      }
+    }
+    for (const [role, entry] of state.members) {
+      if (state.outcomes.some((outcome) => outcome.role === role)) continue;
+      const outcome = { role };
+      if (!entry.run) {
+        Object.assign(outcome, { phase: 'start_failed', terminal: true, narrative: null, resultSha: null, error: entry.startError });
+      } else {
+        try {
+          const view = await entry.run.status();
+          const outline = view?.view ?? view ?? {};
+          outcome.phase = outline.phase ?? null;
+          outcome.terminal = terminalFrom(outline);
+          outcome.narrative = outline.narrative ?? null;
+          outcome.resultSha = await materialize(entry);
+        } catch (error) {
+          Object.assign(outcome, { phase: 'outcome_error', terminal: false, resultSha: null, error: { code: error?.code ?? null, message: String(error?.message ?? error) } });
+        }
+      }
+      state.outcomes.push(outcome);
+    }
+    return [...state.outcomes];
+  }
+
+  async function close({ reason = 'Wave settled.' } = {}) {
+    const stops = [];
+    for (const [role, entry] of state.members) {
+      if (!entry.run) continue;
+      try {
+        const stopped = await entry.run.stop(reason);
+        stops.push({ role, stop: stopped?.stop ?? null, ownership: stopped?.ownership ?? null });
+      } catch (error) {
+        stops.push({ role, error: { code: error?.code ?? null, message: String(error?.message ?? error) } });
+      }
+    }
+    state.stops.push(...stops);
+    const remainingCount = stops.reduce((total, stop) => total + (stop.error ? 1 : (stop.ownership?.remainingCount ?? 0)), 0);
+    return { reason, stops, remainingCount };
+  }
+
+  function evidence() {
+    return {
+      schemaVersion: 1,
+      startedAt: new Date(state.startedAt).toISOString(),
+      members: members.map(({ role }) => role),
+      outcomes: [...state.outcomes],
+      steering: [...state.steering],
+      stops: [...state.stops],
+      progress: [...state.progress],
+    };
+  }
+
+  const wave = {
+    get runs() {
+      return new Map([...state.members.entries()].filter(([, entry]) => entry.run).map(([role, entry]) => [role, entry.run]));
+    },
+    progress, send, stopMember, settle, close, evidence,
+  };
+  return Object.freeze(wave);
+}
+
+export default createWave;

--- a/impl/src/wave.mjs
+++ b/impl/src/wave.mjs
@@ -6,6 +6,8 @@
 // Program-IR aligned: members ↔ parallel branches, settle ↔ join, materialization ↔ collect,
 // stopMember ↔ selective stop, evidence() ↔ the wave trace. It holds no durable state of its own.
 
+import { statSync } from 'node:fs';
+
 const TERMINAL_PHASES = new Set(['stopped', 'failed', 'cancelled', 'completed']);
 const SUCCESS_RESTING = 'work_completed';
 const RESULT_SHA = /^[a-f0-9]{40,64}$/u;
@@ -16,7 +18,7 @@ function waveError(message, code = 'wave_invalid') {
   return Object.assign(new TypeError(message), { code });
 }
 
-function validateMember(member, index) {
+function validateMember(member, index, repoRoot = null) {
   if (!member || typeof member !== 'object' || Array.isArray(member)) {
     throw waveError(`wave member[${index}] must be an object`);
   }
@@ -32,11 +34,21 @@ function validateMember(member, index) {
   }
   for (const entry of member.scope) {
     if (!GLOB_MAGIC.test(entry)) {
-      const basename = entry.replace(/\/+$/u, '').split('/').pop() ?? '';
-      if (!basename.includes('.')) {
+      const trimmed = entry.replace(/\/+$/u, '');
+      const basename = trimmed.split('/').pop() ?? '';
+      // docs/31 #5: bare directories match only themselves under glob semantics. When repoRoot
+      // is available the filesystem decides; otherwise the basename-dot heuristic decides, and a
+      // non-existent dotless path is treated as an intended directory (corrective form shown).
+      let isDirectory = !basename.includes('.');
+      if (repoRoot) {
+        try {
+          isDirectory = statSync(`${repoRoot}/${trimmed}`).isDirectory() || isDirectory;
+        } catch { /* path does not exist yet; the heuristic stands */ }
+      }
+      if (isDirectory) {
         throw waveError(
           `wave member ${role} scope entry "${entry}" names a bare directory, which matches only `
-          + `itself under glob scope semantics; use "${entry.replace(/\/+$/u, '')}/**" instead`,
+          + `itself under glob scope semantics; use "${trimmed}/**" instead`,
           'wave_scope_invalid',
         );
       }
@@ -86,7 +98,7 @@ export async function createWave(baton, options = {}) {
   }
   const approve = options.approve !== false;
   const repoRoot = typeof options.repoRoot === 'string' && options.repoRoot.length > 0 ? options.repoRoot : null;
-  const members = membersInput.map(validateMember);
+  const members = membersInput.map((member, index) => validateMember(member, index, repoRoot));
   if (new Set(members.map(({ role }) => role)).size !== members.length) {
     throw waveError('wave member roles contain duplicates');
   }
@@ -140,13 +152,28 @@ export async function createWave(baton, options = {}) {
 
   const pumps = new Map();
   function armPump(entry) {
-    if (!entry.run || pumps.get(entry.member.role) === true) return;
-    pumps.set(entry.member.role, true);
-    entry.run.complete().then(
-      () => { pumps.set(entry.member.role, false); },
-      () => { pumps.set(entry.member.role, false); },
+    if (!entry.run || pumps.get(entry.member.role)) return;
+    const promise = entry.run.complete().then(
+      () => { pumps.delete(entry.member.role); },
+      () => { pumps.delete(entry.member.role); },
     );
+    pumps.set(entry.member.role, promise);
   }
+
+  // docs/31: pumps never outlive the call that armed them. Before settle returns (including its
+  // own timeout), drain outstanding pumps with a bounded grace so nothing keeps driving in the
+  // background and races close().
+  async function drainPumps(graceMs = 2_000) {
+    if (pumps.size === 0) return true;
+    const pending = [...pumps.values()];
+    const drained = await Promise.race([
+      Promise.allSettled(pending).then(() => true),
+      new Promise((resolve) => setTimeout(() => resolve(false), graceMs)),
+    ]);
+    return drained;
+  }
+
+  function pumpQuiescent() { return pumps.size === 0; }
 
   async function send(role, message, options = {}) {
     const entry = state.members.get(role);
@@ -180,9 +207,11 @@ export async function createWave(baton, options = {}) {
 
   async function materialize(entry) {
     const { member, run } = entry;
+    // Result section first (docs/31 #6): run.inspect returns `section` at top level — there is
+    // no `.view` wrapper; a `.view.section` read silently disables this path.
     try {
       const results = await run.inspect({ depth: 'section', section: 'result' });
-      const value = results?.view?.section?.items?.[0]?.value;
+      const value = results?.section?.items?.[0]?.value;
       if (RESULT_SHA.test(value?.sha ?? '')) return value.sha;
     } catch { /* section projection can be empty post-stop */ }
     if (!repoRoot || !member.report) return null;
@@ -244,23 +273,37 @@ export async function createWave(baton, options = {}) {
       }
       state.outcomes.push(outcome);
     }
+    const pumpsDrained = await drainPumps();
+    state.pumpDrained = pumpsDrained && pumpQuiescent();
     return [...state.outcomes];
   }
 
   async function close({ reason = 'Wave settled.' } = {}) {
+    await drainPumps();
     const stops = [];
     for (const [role, entry] of state.members) {
       if (!entry.run) continue;
       try {
         const stopped = await entry.run.stop(reason);
-        stops.push({ role, stop: stopped?.stop ?? null, ownership: stopped?.ownership ?? null });
+        const outline = stopped?.outline ?? {};
+        // Residue truth is the RunView's resources block (ownedCount/cleanupState); a stop view
+        // without it is reported as unknown, never coalesced to zero (docs/31 #8).
+        const resources = outline.resources ?? null;
+        const ownedCount = Number.isSafeInteger(resources?.ownedCount) ? resources.ownedCount : null;
+        stops.push({
+          role,
+          stop: stopped?.stop ?? null,
+          resources: resources ? { state: resources.state ?? null, cleanupState: resources.cleanupState ?? null, ownedCount } : null,
+          ownedCount,
+        });
       } catch (error) {
-        stops.push({ role, error: { code: error?.code ?? null, message: String(error?.message ?? error) } });
+        stops.push({ role, ownedCount: null, error: { code: error?.code ?? null, message: String(error?.message ?? error) } });
       }
     }
     state.stops.push(...stops);
-    const remainingCount = stops.reduce((total, stop) => total + (stop.error ? 1 : (stop.ownership?.remainingCount ?? 0)), 0);
-    return { reason, stops, remainingCount };
+    const remainingCount = stops.reduce((total, stop) => total + (stop.ownedCount ?? 1), 0);
+    const residueUnknown = stops.some((stop) => stop.ownedCount === null);
+    return { reason, stops, remainingCount, residueUnknown };
   }
 
   function evidence() {
@@ -272,6 +315,7 @@ export async function createWave(baton, options = {}) {
       steering: [...state.steering],
       stops: [...state.stops],
       progress: [...state.progress],
+      pumpDrained: state.pumpDrained === true,
     };
   }
 
@@ -279,6 +323,7 @@ export async function createWave(baton, options = {}) {
     get runs() {
       return new Map([...state.members.entries()].filter(([, entry]) => entry.run).map(([role, entry]) => [role, entry.run]));
     },
+    get pumpQuiescent() { return pumpQuiescent(); },
     progress, send, stopMember, settle, close, evidence,
   };
   return Object.freeze(wave);

--- a/impl/src/wave.mjs
+++ b/impl/src/wave.mjs
@@ -87,6 +87,34 @@ function attentionFrom(outline) {
   return null;
 }
 
+// Resolve one preserved result pin for a member from refs/baton/results/* — the documented
+// fallback when the result section has no authoritative sha (docs/31 #6). Disambiguation is by
+// git path existence (the pin's tree must carry `report`), a start-time window, and an exclusion
+// set for pins already attributed to other members — never by newest-pin guessing. Exported so
+// the disambiguation is directly pinnable (W10).
+export async function resolveResultPin({ repoRoot, report, startedAtMs, excludeShas = [] }) {
+  if (typeof repoRoot !== 'string' || repoRoot.length === 0 || typeof report !== 'string'
+    || report.length === 0 || !Number.isSafeInteger(startedAtMs)) return null;
+  const { execFileSync } = await import('node:child_process');
+  let pins;
+  try {
+    pins = execFileSync('/usr/bin/git', ['for-each-ref', 'refs/baton/results/', '--format=%(objectname) %(committerdate:unix)'], { cwd: repoRoot, encoding: 'utf8' })
+      .trim().split('\n').filter(Boolean)
+      .map((row) => ({ sha: row.split(' ')[0], at: Number(row.split(' ')[1]) }))
+      .filter((pin) => pin.at * 1000 >= startedAtMs - 60_000)
+      .sort((left, right) => right.at - left.at);
+  } catch { return null; }
+  const excluded = new Set(excludeShas);
+  for (const pin of pins) {
+    if (excluded.has(pin.sha)) continue;
+    try {
+      execFileSync('/usr/bin/git', ['cat-file', '-e', `${pin.sha}:${report}`], { cwd: repoRoot, stdio: 'ignore' });
+      return pin.sha;
+    } catch { /* pin does not carry this report path */ }
+  }
+  return null;
+}
+
 export async function createWave(baton, options = {}) {
   if (!baton || !baton.runs || typeof baton.runs.start !== 'function') {
     throw waveError('createWave requires a Baton client facade with runs.start');
@@ -215,24 +243,12 @@ export async function createWave(baton, options = {}) {
       if (RESULT_SHA.test(value?.sha ?? '')) return value.sha;
     } catch { /* section projection can be empty post-stop */ }
     if (!repoRoot || !member.report) return null;
-    let pins;
-    try {
-      pins = (await import('node:child_process')).execFileSync('/usr/bin/git', ['for-each-ref', 'refs/baton/results/', '--format=%(objectname) %(committerdate:unix)'], { cwd: repoRoot, encoding: 'utf8' })
-        .trim().split('\n').filter(Boolean)
-        .map((row) => ({ sha: row.split(' ')[0], at: Number(row.split(' ')[1]) }))
-        .filter((pin) => pin.at * 1000 >= state.startedAt - 60_000)
-        .sort((left, right) => right.at - left.at);
-    } catch { return null; }
-    const used = state.outcomes.map((outcome) => outcome.resultSha).filter(Boolean);
-    const { execFileSync } = await import('node:child_process');
-    for (const pin of pins) {
-      if (used.includes(pin.sha)) continue;
-      try {
-        execFileSync('/usr/bin/git', ['cat-file', '-e', `${pin.sha}:${member.report}`], { cwd: repoRoot, stdio: 'ignore' });
-        return pin.sha;
-      } catch { /* pin does not carry this report path */ }
-    }
-    return null;
+    return resolveResultPin({
+      repoRoot,
+      report: member.report,
+      startedAtMs: state.startedAt,
+      excludeShas: state.outcomes.map((outcome) => outcome.resultSha).filter(Boolean),
+    });
   }
 
   async function settle({ timeoutMs = 60_000 } = {}) {

--- a/impl/test/wave-driver-red.test.mjs
+++ b/impl/test/wave-driver-red.test.mjs
@@ -1,0 +1,306 @@
+// Wave driver surface (docs/31) red suite: first-class orchestration waves over any Baton
+// command port. Every row pins one receipted bespoke-driver failure mode: passive-status
+// stalls, pump-as-terminal kills, fail-fast cascades, terminal-taxonomy confusion, glob-scope
+// misuse, pin-fallback ambiguity, stopMember dispatch races, and watchdog-skipped outcomes.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { BatonApplication } from '../src/application.mjs';
+import { MockAdapter } from '../src/adapter.mjs';
+import { bindBaton, createDriver } from '../src/index.mjs';
+import { createWave } from '../src/wave.mjs';
+
+const repoId = 'repo-wave-driver';
+
+function root(label) {
+  const dir = mkdtempSync(join(tmpdir(), `baton-wave-${label}-`));
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['-c', 'user.name=Baton Test', '-c', 'user.email=baton@example.test', 'commit', '--allow-empty', '-q', '-m', 'base'], { cwd: dir });
+  return dir;
+}
+
+function principal(id) { return Object.freeze({ actor: 'test', principalId: id, sessionId: `session-${id}` }); }
+
+// One MockAdapter whose spawn() selects a scenario by matching the member marker in the brief.
+function markerAdapter(scenariosByMarker, tracker = { calls: [] }) {
+  const adapter = new MockAdapter({ scenario: scenariosByMarker.default ?? { outcome: 'completed' } });
+  const baseCard = adapter.card.bind(adapter);
+  adapter.card = () => ({
+    ...baseCard(),
+    modelSelection: {
+      mode: 'exact', configuredDefault: 'mock-model', available: ['mock-model'],
+      family: 'mock', acceptedPrefixes: [], acceptedAliases: [],
+      reasoningEffort: ['low'], serviceTier: null,
+      provenance: 'wave-driver-test', refreshedAt: null,
+    },
+  });
+  const nativeSpawn = adapter.spawn.bind(adapter);
+  adapter.spawn = (worker, brief, options) => {
+    const goal = brief?.goal ?? '';
+    const marker = Object.keys(scenariosByMarker).find((key) => key !== 'default' && goal.includes(key));
+    const scenario = scenariosByMarker[marker] ?? scenariosByMarker.default;
+    tracker.calls.push({ worker, marker: marker ?? 'default' });
+    return nativeSpawn(worker, brief, { ...options, scenario });
+  };
+  return adapter;
+}
+
+function harness(t, scenariosByMarker, tracker) {
+  const repo = root('repo');
+  const logDir = root('log');
+  mkdirSync(join(repo, 'reports'), { recursive: true });
+  const adapters = { mock: markerAdapter(scenariosByMarker, tracker) };
+  const driver = createDriver({
+    repoRoot: repo,
+    repoId,
+    logDir,
+    adapters,
+    stopDeadlineMs: 2_000,
+    goalPlanAuthority: {
+      policy: Object.freeze({
+        schemaVersion: 1,
+        repoId,
+        mandatory: true,
+        approvalTtlMs: 60 * 60 * 1_000,
+        riskClasses: ['low', 'medium', 'high', 'critical'],
+        effectClasses: ['repository_edit', 'provider_call'],
+        capabilityClasses: ['code', 'test'],
+        limits: Object.freeze({
+          maxGoalVersions: 16, maxPlanVersions: 16, maxNodes: 32, maxDepsPerNode: 16,
+          maxTextBytes: 4_096, maxItems: 64, maxScopePaths: 64, maxRouteValues: 32,
+          maxGoalBytes: 64 * 1_024, maxPlanBytes: 256 * 1_024, maxStatusBytes: 256 * 1_024,
+          maxTokens: 1_000_000, maxUsd: 100, maxWallMin: 24 * 60, maxProviderTurns: 10_000,
+        }),
+      }),
+      authorize: async () => true,
+    },
+  });
+  const application = new BatonApplication({
+    driver,
+    repoId,
+    profiles: {
+      default: Object.freeze({
+        schemaVersion: 1,
+        repoId,
+        definitionOfDone: ['deployment verification passes'],
+        constraints: [],
+        risk: 'low',
+        goalBudget: { tokens: 200_000, usd: 20, wallMin: 120, providerTurns: 64 },
+        nodeBudget: { tokens: 50_000, usd: 5, wallMin: 30, providerTurns: 16 },
+        pathScope: ['**'],
+        verification: {
+          command: 'true', arguments: [], cwd: '.', envAllowlist: [],
+          expectExit: 0, expectResult: 'exit_code', timeoutMs: 30_000, maxOutputBytes: 65536,
+          requiredPredecessorEvidence: [],
+        },
+        routes: [{ harness: 'mock', model: 'mock-model', effort: 'low' }],
+        capabilities: ['code', 'test'],
+        effects: ['provider_call', 'repository_edit'],
+        resultPolicy: { mode: 'manual', maxAdoptedResults: 1, locator: 'git_ref' },
+      }),
+    },
+    defaults: { profile: 'default', route: null },
+    principals: {
+      planner: principal('application-planner'),
+      dispatcher: principal('application-dispatcher'),
+      observer: principal('application-observer'),
+    },
+    authorize: async () => true,
+  });
+  const baton = bindBaton(application, principal('wave-owner'));
+  t.after(async () => {
+    await driver.closeAuthority?.();
+    await driver.coordination?.releaseWriterLease?.();
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(logDir, { recursive: true, force: true });
+  });
+  return { application, baton, driver, repo };
+}
+
+const member = (role, objective, options = {}) => ({
+  role,
+  objective: `${objective} (marker:${role})`,
+  harness: 'mock', model: 'mock-model', effort: 'low',
+  scope: ['reports/**'],
+  report: `reports/${role}.md`,
+  ...options,
+});
+
+test('W1: waves.start begins members individually and explicitly approves them — nothing parks at awaiting_plan_approval', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+    beta: { outcome: 'completed', edits: [{ path: 'reports/beta.md', content: 'beta report\n' }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo, 
+    members: [member('alpha', 'write the alpha report'), member('beta', 'write the beta report')],
+  });
+  const progress = await wave.progress();
+  for (const entry of progress.members) {
+    assert.notEqual(entry.phase, 'awaiting_plan_approval', `${entry.role} must not park on a silent authority gate`);
+  }
+  const outcomes = await wave.settle({ timeoutMs: 20_000 });
+  assert.equal(outcomes.length, 2);
+  for (const outcome of outcomes) {
+    assert.ok(outcome.terminal === true || outcome.phase === 'work_completed', `${outcome.role} settled`);
+    assert.match(outcome.resultSha ?? '', /^[a-f0-9]{40}$/u, `${outcome.role} preserved result`);
+  }
+  await wave.close({ reason: 'W1 settled.' });
+
+  const parked = await createWave(baton, {
+    members: [member('gamma', 'write the gamma report')],
+    approve: false,
+  });
+  const parkedProgress = await parked.progress();
+  assert.equal(parkedProgress.members[0].phase, 'awaiting_plan_approval');
+  await parked.close({ reason: 'W1 unapproved cleanup.' });
+});
+
+test('W2: one member crashing changes nothing about the sibling lifecycle (no fail-fast cascade)', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+    beta: { outcome: 'completed', crashAfterMs: 50, edits: [{ path: 'reports/beta.md', content: 'beta report\n', delayMs: 1_000 }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo, 
+    members: [member('alpha', 'write the alpha report'), member('beta', 'crash immediately')],
+  });
+  const outcomes = await wave.settle({ timeoutMs: 20_000 });
+  const alpha = outcomes.find((outcome) => outcome.role === 'alpha');
+  const beta = outcomes.find((outcome) => outcome.role === 'beta');
+  assert.match(alpha.resultSha ?? '', /^[a-f0-9]{40}$/u, 'sibling completes and preserves its result');
+  assert.notEqual(beta.phase, 'work_completed');
+  assert.notEqual(beta.resultSha ?? null, alpha.resultSha);
+  const stop = await wave.close({ reason: 'W2 settled.' });
+  assert.equal(stop.remainingCount, 0);
+});
+
+test('W3: settle always produces an outcome for every member, including a member that never finishes before the timeout', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+    beta: { outcome: 'completed', edits: [{ path: 'reports/beta.md', content: 'beta report\n', delayMs: 60_000 }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo, 
+    members: [member('alpha', 'write the alpha report'), member('beta', 'block forever')],
+  });
+  const outcomes = await wave.settle({ timeoutMs: 2_000 });
+  assert.equal(outcomes.length, 2, 'every member gets an outcome even after the settle timeout');
+  const alpha = outcomes.find((outcome) => outcome.role === 'alpha');
+  const beta = outcomes.find((outcome) => outcome.role === 'beta');
+  assert.match(alpha.resultSha ?? '', /^[a-f0-9]{40}$/u);
+  assert.equal(beta.resultSha, null);
+  assert.equal(beta.terminal, false);
+  const stop = await wave.close({ reason: 'W3 watchdog cleanup.' });
+  assert.equal(stop.remainingCount, 0);
+});
+
+test('W4: a blocked member surfaces attention through progress, never reads as completed', async (t) => {
+  const scenarios = {
+    alpha: {
+      outcome: 'completed',
+      edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }],
+      ask: { kind: 'question', question: 'which section should this cover?', blocking: true },
+    },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo,  members: [member('alpha', 'block and wait')] });
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const progress = await wave.progress();
+  const alpha = progress.members[0];
+  assert.notEqual(alpha.phase, 'work_completed');
+  assert.notEqual(alpha.phase, 'completed');
+  assert.ok(alpha.attention !== null && alpha.attention !== undefined && alpha.attention !== 'clear',
+    'blocked members surface attention for the orchestrator');
+  await wave.close({ reason: 'W4 cleanup.' });
+});
+
+test('W5: a bare-directory scope fails admission with the corrective glob form; glob scopes pass', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  await assert.rejects(() => createWave(baton, {
+    members: [member('alpha', 'write the alpha report', { scope: ['reports'] })],
+  }), (error) => error.code === 'wave_scope_invalid' && /reports\/\*\*/u.test(error.message));
+  const wave = await createWave(baton, { repoRoot: repo,  members: [member('alpha', 'write the alpha report')] });
+  const outcomes = await wave.settle({ timeoutMs: 20_000 });
+  assert.match(outcomes[0].resultSha ?? '', /^[a-f0-9]{40}$/u);
+  await wave.close({ reason: 'W5 settled.' });
+});
+
+test('W6: stopMember stops exactly that member and the sibling continues to completion', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+    beta: { outcome: 'completed', edits: [{ path: 'reports/beta.md', content: 'beta report\n', delayMs: 30_000 }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo, 
+    members: [member('alpha', 'write the alpha report'), member('beta', 'write the beta report slowly')],
+  });
+  const stop = await wave.stopMember('beta', { reason: 'selective stop proof' });
+  assert.ok(stop.admitted === true || stop.stopped === true, 'selective stop admitted');
+  const outcomes = await wave.settle({ timeoutMs: 20_000 });
+  const alpha = outcomes.find((outcome) => outcome.role === 'alpha');
+  const beta = outcomes.find((outcome) => outcome.role === 'beta');
+  assert.match(alpha.resultSha ?? '', /^[a-f0-9]{40}$/u, 'sibling completes after the selective stop');
+  assert.notEqual(beta.phase, 'work_completed');
+  const closeStop = await wave.close({ reason: 'W6 settled.' });
+  assert.equal(closeStop.remainingCount, 0);
+});
+
+test('W7: materialized results disambiguate preserved pins by report path, never by newest-pin guessing', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+    beta: { outcome: 'completed', edits: [{ path: 'reports/beta.md', content: 'beta report\n' }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo, 
+    members: [member('alpha', 'write the alpha report'), member('beta', 'write the beta report')],
+  });
+  const outcomes = await wave.settle({ timeoutMs: 20_000 });
+  for (const outcome of outcomes) {
+    const listed = execFileSync('git', ['ls-tree', '-r', '--name-only', outcome.resultSha, '--', 'reports'], { cwd: repo, encoding: 'utf8' }).trim();
+    assert.equal(listed, `reports/${outcome.role}.md`, `${outcome.role} result binds its own report path`);
+    const body = execFileSync('git', ['show', `${outcome.resultSha}:reports/${outcome.role}.md`], { cwd: repo, encoding: 'utf8' });
+    assert.match(body, new RegExp(`${outcome.role} report`, 'u'));
+  }
+  await wave.close({ reason: 'W7 settled.' });
+});
+
+test('W8: close returns per-member stops with ownership receipts and a zero-residue summary', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+    beta: { outcome: 'completed', edits: [{ path: 'reports/beta.md', content: 'beta report\n' }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await createWave(baton, { repoRoot: repo, 
+    members: [member('alpha', 'write the alpha report'), member('beta', 'write the beta report')],
+  });
+  await wave.settle({ timeoutMs: 20_000 });
+  const stop = await wave.close({ reason: 'W8 settled.' });
+  assert.equal(stop.stops.length, 2);
+  assert.equal(stop.remainingCount, 0);
+  const record = wave.evidence();
+  assert.equal(record.members.length, 2);
+  assert.ok(Array.isArray(record.outcomes) && Array.isArray(record.progress) && Array.isArray(record.stops));
+});
+
+test('W9: the baton.waves facade starts a wave through the client getter', async (t) => {
+  const scenarios = {
+    alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
+  };
+  const { baton, repo } = harness(t, scenarios);
+  const wave = await baton.waves.start({
+    repoRoot: repo,
+    members: [member('alpha', 'write the alpha report')],
+  });
+  const outcomes = await wave.settle({ timeoutMs: 20_000 });
+  assert.match(outcomes[0].resultSha ?? '', /^[a-f0-9]{40}$/u);
+  await wave.close({ reason: 'W9 settled.' });
+});

--- a/impl/test/wave-driver-red.test.mjs
+++ b/impl/test/wave-driver-red.test.mjs
@@ -1,7 +1,8 @@
 // Wave driver surface (docs/31) red suite: first-class orchestration waves over any Baton
 // command port. Every row pins one receipted bespoke-driver failure mode: passive-status
 // stalls, pump-as-terminal kills, fail-fast cascades, terminal-taxonomy confusion, glob-scope
-// misuse, pin-fallback ambiguity, stopMember dispatch races, and watchdog-skipped outcomes.
+// misuse, pin-fallback ambiguity (positively, via synthetic sibling pins), selective member
+// stop, pump leaks on settle timeout, and watchdog-skipped outcomes.
 
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
@@ -320,4 +321,35 @@ test('W9: the baton.waves facade starts a wave through the client getter', async
   const outcomes = await wave.settle({ timeoutMs: 20_000 });
   assert.match(outcomes[0].resultSha ?? '', /^[a-f0-9]{40}$/u);
   await wave.close({ reason: 'W9 settled.' });
+});
+
+test('W10: pin resolution returns the path-carrying pin, never the newest pin (failure mode #6 positively pinned)', async (t) => {
+  const repo = root('pins');
+  mkdirSync(join(repo, 'reports'), { recursive: true });
+  writeFileSync(join(repo, 'reports', 'alpha.md'), 'alpha report\n');
+  execFileSync('git', ['add', 'reports/alpha.md'], { cwd: repo });
+  execFileSync('git', ['-c', 'user.name=Baton Test', '-c', 'user.email=baton@example.test', 'commit', '-q', '-m', 'alpha pin'], {
+    cwd: repo,
+    env: { ...process.env, GIT_AUTHOR_DATE: '@1700000000 +0000', GIT_COMMITTER_DATE: '@1700000000 +0000' },
+  });
+  const olderPin = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+  execFileSync('git', ['update-ref', `refs/baton/results/${olderPin}`, olderPin], { cwd: repo });
+  execFileSync('git', ['rm', '-q', 'reports/alpha.md'], { cwd: repo });
+  execFileSync('git', ['-c', 'user.name=Baton Test', '-c', 'user.email=baton@example.test', 'commit', '-q', '-m', 'newer sibling pin without the path'], {
+    cwd: repo,
+    env: { ...process.env, GIT_AUTHOR_DATE: '@1700003600 +0000', GIT_COMMITTER_DATE: '@1700003600 +0000' },
+  });
+  const newerPin = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim();
+  execFileSync('git', ['update-ref', `refs/baton/results/${newerPin}`, newerPin], { cwd: repo });
+  t.after(() => rmSync(repo, { recursive: true, force: true }));
+
+  const { resolveResultPin } = await import('../src/wave.mjs');
+  const startedAtMs = 1_700_000_000_000 - 30_000;
+  const resolved = await resolveResultPin({ repoRoot: repo, report: 'reports/alpha.md', startedAtMs });
+  assert.equal(resolved, olderPin, 'the path-carrying pin wins over the newer pathless sibling');
+  assert.notEqual(resolved, newerPin);
+  const excluded = await resolveResultPin({ repoRoot: repo, report: 'reports/alpha.md', startedAtMs, excludeShas: [olderPin] });
+  assert.equal(excluded, null, 'used-sha exclusion is honored');
+  const windowed = await resolveResultPin({ repoRoot: repo, report: 'reports/alpha.md', startedAtMs: 1_700_003_700_000 });
+  assert.equal(windowed, null, 'the start-time window filters stale pins');
 });

--- a/impl/test/wave-driver-red.test.mjs
+++ b/impl/test/wave-driver-red.test.mjs
@@ -131,13 +131,14 @@ const member = (role, objective, options = {}) => ({
   ...options,
 });
 
-test('W1: waves.start begins members individually and explicitly approves them — nothing parks at awaiting_plan_approval', async (t) => {
+test('W1: waves.start begins members individually and explicitly approves them — nothing parks at awaiting_plan_approval; the result section alone materializes results', async (t) => {
   const scenarios = {
     alpha: { outcome: 'completed', edits: [{ path: 'reports/alpha.md', content: 'alpha report\n' }] },
     beta: { outcome: 'completed', edits: [{ path: 'reports/beta.md', content: 'beta report\n' }] },
   };
   const { baton, repo } = harness(t, scenarios);
-  const wave = await createWave(baton, { repoRoot: repo, 
+  // No repoRoot: the documented surface alone must materialize via the result section (P1-A fix).
+  const wave = await createWave(baton, {
     members: [member('alpha', 'write the alpha report'), member('beta', 'write the beta report')],
   });
   const progress = await wave.progress();
@@ -148,7 +149,7 @@ test('W1: waves.start begins members individually and explicitly approves them �
   assert.equal(outcomes.length, 2);
   for (const outcome of outcomes) {
     assert.ok(outcome.terminal === true || outcome.phase === 'work_completed', `${outcome.role} settled`);
-    assert.match(outcome.resultSha ?? '', /^[a-f0-9]{40}$/u, `${outcome.role} preserved result`);
+    assert.match(outcome.resultSha ?? '', /^[a-f0-9]{40}$/u, `${outcome.role} result section preserved result`);
   }
   await wave.close({ reason: 'W1 settled.' });
 
@@ -196,6 +197,7 @@ test('W3: settle always produces an outcome for every member, including a member
   assert.match(alpha.resultSha ?? '', /^[a-f0-9]{40}$/u);
   assert.equal(beta.resultSha, null);
   assert.equal(beta.terminal, false);
+  assert.equal(wave.pumpQuiescent, true, 'no pump outlives a timed-out settle (P2-E fix)');
   const stop = await wave.close({ reason: 'W3 watchdog cleanup.' });
   assert.equal(stop.remainingCount, 0);
 });
@@ -228,6 +230,13 @@ test('W5: a bare-directory scope fails admission with the corrective glob form; 
   await assert.rejects(() => createWave(baton, {
     members: [member('alpha', 'write the alpha report', { scope: ['reports'] })],
   }), (error) => error.code === 'wave_scope_invalid' && /reports\/\*\*/u.test(error.message));
+  mkdirSync(join(repo, 'assets', 'v1.2'), { recursive: true });
+  await assert.rejects(() => createWave(baton, { repoRoot: repo, members: [member('alpha', 'x', { scope: ['assets/v1.2'] })] }),
+    (error) => error.code === 'wave_scope_invalid' && /v1\.2\/\*\*/u.test(error.message),
+    'an existing dotted directory is rejected by the filesystem check');
+  await assert.rejects(() => createWave(baton, { repoRoot: repo, members: [member('alpha', 'x', { scope: ['nowhere'] })] }),
+    (error) => error.code === 'wave_scope_invalid' && /nowhere\/\*\*/u.test(error.message),
+    'a non-existent dotless path is rejected as an intended directory');
   const wave = await createWave(baton, { repoRoot: repo,  members: [member('alpha', 'write the alpha report')] });
   const outcomes = await wave.settle({ timeoutMs: 20_000 });
   assert.match(outcomes[0].resultSha ?? '', /^[a-f0-9]{40}$/u);
@@ -244,7 +253,8 @@ test('W6: stopMember stops exactly that member and the sibling continues to comp
     members: [member('alpha', 'write the alpha report'), member('beta', 'write the beta report slowly')],
   });
   const stop = await wave.stopMember('beta', { reason: 'selective stop proof' });
-  assert.ok(stop.admitted === true || stop.stopped === true, 'selective stop admitted');
+  assert.equal(stop.stopped, true, 'plain-run members stop through run.stop (P1-C branch honesty)');
+  assert.notEqual(stop.admitted, true, 'stop_member is a workflow-member path and must not be claimed for plain runs');
   const outcomes = await wave.settle({ timeoutMs: 20_000 });
   const alpha = outcomes.find((outcome) => outcome.role === 'alpha');
   const beta = outcomes.find((outcome) => outcome.role === 'beta');
@@ -252,6 +262,7 @@ test('W6: stopMember stops exactly that member and the sibling continues to comp
   assert.notEqual(beta.phase, 'work_completed');
   const closeStop = await wave.close({ reason: 'W6 settled.' });
   assert.equal(closeStop.remainingCount, 0);
+  assert.equal(closeStop.residueUnknown, false);
 });
 
 test('W7: materialized results disambiguate preserved pins by report path, never by newest-pin guessing', async (t) => {
@@ -285,10 +296,16 @@ test('W8: close returns per-member stops with ownership receipts and a zero-resi
   await wave.settle({ timeoutMs: 20_000 });
   const stop = await wave.close({ reason: 'W8 settled.' });
   assert.equal(stop.stops.length, 2);
+  for (const entry of stop.stops) {
+    assert.ok(entry.resources !== null, 'every stop carries the RunView resources block (P1-B fix)');
+    assert.equal(Number.isSafeInteger(entry.ownedCount), true, 'residue is a real count, never coalesced');
+  }
   assert.equal(stop.remainingCount, 0);
+  assert.equal(stop.residueUnknown, false);
   const record = wave.evidence();
   assert.equal(record.members.length, 2);
   assert.ok(Array.isArray(record.outcomes) && Array.isArray(record.progress) && Array.isArray(record.stops));
+  assert.equal(record.pumpDrained, true);
 });
 
 test('W9: the baton.waves facade starts a wave through the client getter', async (t) => {


### PR DESCRIPTION
## What

A first-class, orchestrator-side Wave surface so an orchestration wave is **data** — a member roster plus objectives — and every lifecycle semantic is baton's own, not the caller's bespoke driver. Remediates the receipted agentic-experience defect that every wave cost a ~300-line bespoke driver plus hours of orchestrator-side bugs (enumerated in [docs/31](docs/31-wave-driver-ax.md) from the 2026-07-20/21 dogfood).

- `impl/src/wave.mjs` — `createWave(baton, { members, approve = true, repoRoot? })`: per-member isolated start + explicit approval; `progress()` (phase/terminal/attention with `blocked_interaction` synthesis); `send(role)`; `stopMember(role)` (retry-until-stoppable for workflow members, run.stop for plain members); `settle({timeoutMs})` (always produces per-member outcomes; result materialization via result section + path-existence `refs/baton/results` fallback); `close()` (zero-residue summary with ownership receipts); `evidence()` (structured wave record).
- `baton.waves.start(...)` facade on `BatonClient` + `createWave` export from `impl/src/index.mjs`.
- `impl/test/wave-driver-red.test.mjs` — 9 W rows pinning each failure mode against a deterministic MockAdapter harness. **Canonical suite 2487/2487 green.**

## Semantics baked from the dogfood failure log

Passive-status stalls (approval is explicit), pump-as-terminal kills (pumps only push gates), fail-fast cascades (unconditional per-member isolation), terminal-taxonomy confusion (closed terminal set + `work_completed` success-resting), glob-scope misuse (bare-directory refusal with corrective `dir/**`), pin-fallback ambiguity (path-existence disambiguation + start-time window, never newest-pin guessing), stopMember dispatch races (retry-until-stoppable), watchdog-skipped outcomes (settle always produces outcomes).

## Program-IR alignment

The Wave is deliberately the runtime shadow of the §93.24 93E template lowerings (members ↔ parallel branches, settle ↔ join, materialization ↔ collect, stopMember ↔ selective stop, evidence ↔ trace). It holds no durable state, no event-log authority, and no scheduling loop beyond per-member pumping — when Program v1 runtime lands, `baton.waves` becomes a lowering target, not a replacement.

## Non-goals

Wave durability (93B owns durable composition), resident-hosted waves, worker-side access (issue #12), new event kinds or ledger authority beyond the ordinary Run commands it composes.