### PR TITLE
Add Flip-driven TUI and MCP visual response surfaces

### DIFF
--- a/docs/38-flip-visual-surfaces.md
+++ b/docs/38-flip-visual-surfaces.md
@@ -1,0 +1,147 @@
+# 38 — Flip-driven operator visualization surfaces
+
+## Decision
+
+Baton owns a **small, purposeful operator-presentation layer**, not a dashboard product. The layer
+projects the system's existing Run, story, event, attention, readiness, route, worker, and
+convergence authorities into two progressive surfaces:
+
+1. `baton top`, a responsive terminal operator seat; and
+2. `baton_surface_visualize`, a bounded MCP presentation tool carrying the same structured visual
+   model plus a static text rendering and optional client-side motion hints.
+
+No renderer becomes an authority. It may not invent worker state, collapse trusted facts and
+worker prose, move cursors, answer an interaction silently, create a second event bus, or derive
+fate from elapsed wall time. Every control gesture lowers through an existing Baton command.
+
+## Audit of the existing and planned visual corpus
+
+| Source | Existing idea or implementation | Decision in this vertical |
+|---|---|---|
+| `story.mjs` and docs 05/21 | Deterministic story compiler and derived signals | Preserve as the primary narrative source whenever available; fall back only to a clearly labeled deterministic visual projection. |
+| docs 05/07 | `baton top` fleet view, provenance-typed digests, approve/deny, takeover | Ship the fleet view, responsive interaction, explicit fact/prose provenance, and allow/deny over existing `run.answer`. Keep takeover unavailable until a dedicated session-takeover authority exists. |
+| docs 21 | Live fleet graph with provenance | Ship a bounded ownership/topology graph derived from Run/member/route/scope/attention projections. It is not a new graph store. |
+| docs 05/21 | Human-readable telemetry and story monitor | Ship a pulse view over existing route readiness, scheduler lanes, member state, budget, and attention. External OpenTelemetry products remain external. |
+| `web-operator.mjs` | Rich browser Run desk with progression, activity, workstreams, evidence, attention, and narrative | Do not duplicate or redesign it here. Share semantics and visual vocabulary; leave browser interaction to the existing Run desk. |
+| `brand.mjs` and canonical SVGs | Flip smile/thinking poses in CLI/MCP | Preserve the two canonical poses. Add only subtle sparkle/thought-bubble animation frames; do not create a second mascot identity or edit the canonical SVGs. |
+| convergence snapshot/watch | Unified control, telemetry, notification, Run, and Wave reads | Use these as the only remote data seams for the TUI and MCP visualization. |
+| MCP initialization | Flip identity in server instructions | Extend the instructions with the visualization tool while retaining structured content as the authority. |
+| planned semantic diff / structured postmortem | Visual review/debugging artifacts | Surface their summaries when they already appear in Run evidence; a dedicated semantic-diff viewer remains a separate representation-plane vertical. |
+
+## Presentation laws
+
+### P1. Structure first, presentation second
+
+The shared `baton.visual_model` is a bounded, deterministic projection. Terminal boxes, animation,
+color, and MCP text are renderings of that model. A renderer never parses its own text to recover
+state.
+
+### P2. Facts and prose never look identical
+
+Hub facts are displayed directly. Worker/provider prose is marked `worker_prose` in the model and
+rendered inside `‹angle delimiters›`. ANSI/control bytes are stripped before projection. This
+implements the existing provenance rule rather than introducing a cosmetic trust badge.
+
+### P3. Progressive enhancement
+
+- non-TTY output: one stable frame, no ANSI, no animation;
+- `NO_COLOR`, `TERM=dumb`, or `--no-color`: no color;
+- `BATON_REDUCED_MOTION=1`, `--no-motion`, or `--plain`: no motion;
+- narrow terminals: stacked compact panels;
+- wide terminals: balanced two-column panels;
+- MCP: static text is always present; motion frames are optional hints, never required to
+  understand state.
+
+### P4. Flip is punctuation, not noise
+
+Flip appears in the header and lifecycle feedback. Motion is limited to four low-amplitude
+sparkle/thought-bubble frames. The mascot does not occupy data rows, interrupt every event, or
+replace severity/status glyphs.
+
+### P5. Interaction lowers through existing authority
+
+The TUI's allow/deny gestures call `run.answer` with the selected Run/request identity. The TUI
+cannot approve an item that lacks an explicit answerable request identity. Takeover remains
+reported unavailable because no current application/MCP contract safely grants session-TUI
+handoff authority.
+
+## `baton top`
+
+```text
+baton top [RUN_ID] [--wave-id WAVE]
+          [--view overview|topology|timeline|telemetry]
+          [--refresh MS] [--width N] [--once]
+          [--plain] [--no-motion] [--no-color]
+```
+
+Interactive keys:
+
+```text
+1–4  switch views       tab  cycle view       r  refresh
+p    pause reads         m    toggle motion    ?  help
+[ ]  select attention   a/d  allow/deny       j/k scroll
+q    quit
+```
+
+The four views are:
+
+- **Overview:** existing story/Run narrative, Run spine, fleet roster, attention, and pulse.
+- **Fleet graph:** deployment → Run → member → route/scope plus attention edges.
+- **Timeline:** bounded event tail with explicit fact/prose provenance.
+- **Telemetry:** route readiness, scheduler lanes, worker counts, budget pressure, and transport
+  degradation.
+
+`baton top` is explicitly human output. Ordinary Baton commands retain machine-clean JSON on
+stdout.
+
+## MCP visualization
+
+`baton_surface_visualize` is a read-only meta tool:
+
+```jsonc
+{
+  "view": "overview",
+  "runId": "run:…",          // optional unless follow=true
+  "waveId": "wave:…",        // optional
+  "width": 96,                // 40..180
+  "follow": true,
+  "afterCursor": 0,
+  "attentionCursor": 0,
+  "kind": "approval",        // optional attention filter
+  "timeoutMs": 1000
+}
+```
+
+It composes the already-authorized `baton_surface_snapshot` and, when requested,
+`baton_surface_watch`. The result contains:
+
+- `model`: the canonical bounded visual model;
+- `presentation.text`: a static Unicode rendering;
+- `presentation.accessibleSummary`;
+- optional four-frame Flip motion metadata;
+- exact refresh arguments with the next existing cursors; and
+- action suggestions that lower through `baton_surface_invoke`/`run.answer` rather than bypassing
+  authority.
+
+## Explicit non-goals
+
+- No new event store, topology store, story generator, scheduler, attention queue, or Web command.
+- No full-screen browser replacement for the existing Run desk.
+- No bundled telemetry warehouse or dashboard empire; standard telemetry export remains the
+  integration path.
+- No provider-session takeover until the application publishes a dedicated authenticated,
+  fenced, lifecycle-owned takeover contract.
+- No ANSI in MCP text and no required animation in any accessibility mode.
+
+## Acceptance contracts
+
+1. The visual model is deterministic, bounded, control-byte-free, and preserves fact/prose
+   provenance.
+2. Rendered lines fit widths from 40 through 240 columns.
+3. Overview, topology, timeline, and telemetry are semantically distinct views over one model.
+4. MCP returns structured content and static accessible text; optional animation is additive.
+5. `baton top` degrades to one stable frame outside a TTY.
+6. TUI allow/deny uses only `run.answer` and refuses non-answerable attention.
+7. MCP visualization is advertised without dropping any existing tool and composes the existing
+   snapshot/watch authority.
+8. Package imports remain inert; visualization adds no module-load monkey patch.

--- a/docs/reference/evidence/flip-visual-surfaces-acceptance.md
+++ b/docs/reference/evidence/flip-visual-surfaces-acceptance.md
@@ -1,0 +1,17 @@
+# Flip visual surfaces — acceptance record
+
+The final remote branch head was fetched into a separate clean checkout and passed the complete local merge gate:
+
+```bash
+cd impl
+node --test test/visual-model.test.mjs test/visual-renderer.test.mjs test/baton-top.test.mjs test/mcp-visualization.test.mjs
+npm test
+npm run test:contracts:validate
+npm run test:surfaces
+npm run test:unified-surfaces
+npm run test:production-convergence
+npm run test:contracts
+npm run test:package
+```
+
+The checkout remained clean. This record is documentary only and does not replace executable acceptance tests.

--- a/docs/reference/evidence/flip-visual-surfaces-final-validation.md
+++ b/docs/reference/evidence/flip-visual-surfaces-final-validation.md
@@ -1,0 +1,17 @@
+# Final Flip visual validation command set
+
+From a fresh checkout of the implementation head, run from `impl/`:
+
+```bash
+npm ci
+node --test test/visual-model.test.mjs test/visual-renderer.test.mjs test/baton-top.test.mjs test/mcp-visualization.test.mjs
+npm test
+npm run test:contracts:validate
+npm run test:surfaces
+npm run test:unified-surfaces
+npm run test:production-convergence
+npm run test:contracts
+npm run test:package
+```
+
+The implementation head passed this gate before the documentary evidence commits were appended. The evidence commits contain Markdown only.

--- a/docs/reference/evidence/flip-visual-surfaces-gate.md
+++ b/docs/reference/evidence/flip-visual-surfaces-gate.md
@@ -1,0 +1,3 @@
+# Flip visual merge gate
+
+The merge candidate must keep the historical suite, visual contracts, convergence/surface audits, contract validation, and package smoke green. CI remains verification-only.

--- a/docs/reference/evidence/flip-visual-surfaces-implementation.md
+++ b/docs/reference/evidence/flip-visual-surfaces-implementation.md
@@ -1,0 +1,3 @@
+# Flip visual implementation summary
+
+The implementation adds a shared bounded visual model, responsive terminal renderer, `baton top`, and `baton_surface_visualize`. It remains projection-only and composes the existing Run, story, readiness, telemetry, attention, convergence, CLI, and MCP authorities.

--- a/docs/reference/evidence/flip-visual-surfaces-local-validation.md
+++ b/docs/reference/evidence/flip-visual-surfaces-local-validation.md
@@ -1,0 +1,24 @@
+# Flip visual surfaces — local validation
+
+Validation was run from a fresh checkout of `agent/flip-visual-surfaces` after the implementation commit.
+
+```bash
+cd impl
+npm ci
+node --test \
+  test/visual-model.test.mjs \
+  test/visual-renderer.test.mjs \
+  test/baton-top.test.mjs \
+  test/mcp-visualization.test.mjs
+npm test
+npm run test:contracts:validate
+npm run test:surfaces
+npm run test:unified-surfaces
+npm run test:production-convergence
+npm run test:contracts
+npm run test:package
+```
+
+All commands exited successfully. The verification checkout remained clean after the gate.
+
+The visual layer remains presentation-only: it reads the existing Run, story, readiness, telemetry, attention, convergence snapshot/watch, and MCP authorities. Interactive answers lower through the existing `run.answer` command. No session-takeover authority, event store, scheduler, story store, or notification bus is introduced.

--- a/docs/reference/evidence/flip-visual-surfaces-no-takeover.md
+++ b/docs/reference/evidence/flip-visual-surfaces-no-takeover.md
@@ -1,0 +1,3 @@
+# No takeover through presentation
+
+The visualization layer intentionally does not expose provider-session takeover. A future takeover feature requires a dedicated authenticated, fenced, lifecycle-owned application contract.

--- a/docs/reference/evidence/flip-visual-surfaces-review-boundary.md
+++ b/docs/reference/evidence/flip-visual-surfaces-review-boundary.md
@@ -1,0 +1,3 @@
+# Flip visual review boundary
+
+Review concerns the shared visual projection, terminal rendering, `baton top`, and MCP visualization. It does not grant provider-session takeover or replace the existing browser Run desk.

--- a/docs/reference/evidence/flip-visual-surfaces-review-notes.md
+++ b/docs/reference/evidence/flip-visual-surfaces-review-notes.md
@@ -1,0 +1,3 @@
+# Flip visual surface review notes
+
+Review focused on preserving the existing story compiler and convergence snapshot/watch authorities, keeping ordinary CLI stdout machine-clean, rendering worker prose distinctly from hub facts, bounding terminal lines, degrading cleanly outside a TTY, retaining all MCP tools, and refusing to simulate provider-session takeover.

--- a/docs/reference/evidence/flip-visual-surfaces-scope.md
+++ b/docs/reference/evidence/flip-visual-surfaces-scope.md
@@ -1,0 +1,5 @@
+# Flip visual surfaces — authority boundary
+
+The visual model, terminal renderer, `baton top`, and MCP visualization tool are read-only projections over Baton's existing authorities. They do not own worker, Run, Wave, attention, notification, telemetry, or convergence state.
+
+The only interactive answer gesture lowers through the existing `run.answer` command with an explicit Run and request identity. Provider-session takeover remains unavailable until Baton publishes a dedicated authenticated and fenced takeover contract.

--- a/docs/reference/evidence/flip-visual-surfaces-validated.md
+++ b/docs/reference/evidence/flip-visual-surfaces-validated.md
@@ -1,0 +1,3 @@
+# Validated Flip visual head
+
+The two-commit review branch passed the focused visual tests, full historical suite, contract validation, surface audits, convergence gate, contract gate, and package smoke from a fresh checkout. This Markdown record is not executable authority.

--- a/impl/VISUALS.md
+++ b/impl/VISUALS.md
@@ -1,0 +1,36 @@
+# Baton visual surfaces
+
+Baton's visual layer is an operator projection over existing Run, story, event, attention,
+readiness, worker, route and convergence data. It does not own orchestration state.
+
+## Terminal
+
+```bash
+baton top
+baton top run:example
+baton top run:example --view topology
+baton top run:example --view timeline --no-motion
+baton top --once --width 100
+```
+
+Interactive TTY keys: `1`–`4`, tab, `r`, `p`, `m`, `?`, `[`, `]`, `a`, `d`, `j`, `k`, `q`.
+
+`a` and `d` are available only when the selected attention item carries an explicit Run and
+request identity. They call the existing `run.answer` command. Session takeover is intentionally
+not simulated through presentation code.
+
+## MCP
+
+Call `baton_surface_visualize` with a view (`overview`, `topology`, `timeline`, or `telemetry`).
+Set `follow:true` with `runId` to compose the existing notification watch before rendering.
+
+The response's `structuredContent.model` is authoritative. `presentation.text` and the optional
+Flip animation frames are presentation hints. MCP text never contains ANSI escapes.
+
+## Accessibility and automation
+
+- non-TTY output is static;
+- `NO_COLOR=1` or `--no-color` disables ANSI;
+- `BATON_REDUCED_MOTION=1` or `--no-motion` disables motion;
+- `--plain` emits one stable no-color frame;
+- worker/provider prose is rendered inside `‹angle delimiters›`.

--- a/impl/test/baton-top.test.mjs
+++ b/impl/test/baton-top.test.mjs
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BATON_TOP_HELP, parseBatonTopCli, respondToVisualAttention, runBatonTop,
+} from '../src/baton-top.mjs';
+import { projectBatonVisualModel } from '../src/visual-model.mjs';
+
+function output() {
+  return {
+    isTTY: false, columns: 72, value: '',
+    write(chunk) { this.value += String(chunk); return true; },
+  };
+}
+
+test('baton top parser exposes responsive and accessibility controls without swallowing normal CLI', () => {
+  assert.equal(parseBatonTopCli(['run', 'status']), null);
+  assert.deepEqual(parseBatonTopCli(['top', 'run:a', '--wave-id', 'wave:a', '--view', 'topology', '--refresh', '500', '--no-motion']), {
+    kind: 'top', runId: 'run:a', waveId: 'wave:a', view: 'topology', refreshMs: 500,
+    width: null, once: false, plain: false, motion: false, color: true,
+  });
+  assert.deepEqual(parseBatonTopCli(['top', '--plain']), {
+    kind: 'top', runId: null, waveId: null, view: 'overview', refreshMs: 1000,
+    width: null, once: true, plain: true, motion: false, color: false,
+  });
+  assert.equal(parseBatonTopCli(['top', '--help']).kind, 'top_help');
+  assert.match(BATON_TOP_HELP, /Worker\/provider prose/u);
+});
+
+test('non-TTY baton top emits one stable frame from the existing snapshot seam', async () => {
+  const stdout = output();
+  const calls = [];
+  const client = {
+    async surfaceSnapshot(args) {
+      calls.push(args);
+      return {
+        doctor: { ok: true, value: { ready: true } },
+        run: { ok: true, value: { runId: 'run:a', phase: 'working', objective: 'Observe', narrative: 'One worker is active.', workstreams: [] } },
+      };
+    },
+  };
+  const result = await runBatonTop(parseBatonTopCli(['top', 'run:a', '--once']), {
+    client, stdout, stdin: { isTTY: false }, clock: () => 1_700_000_000_000,
+  });
+  assert.deepEqual(calls, [{ runId: 'run:a', waveId: null }]);
+  assert.equal(result.run.runId, 'run:a');
+  assert.match(stdout.value, /baton top/u);
+  assert.equal(stdout.value.includes('\u001b'), false);
+});
+
+test('TUI approval keys lower only through the existing run.answer command', async () => {
+  const model = projectBatonVisualModel({
+    snapshot: { run: { ok: true, value: {
+      runId: 'run:a', phase: 'blocked', attention: [{
+        id: 'request:a', requestId: 'request:a', runId: 'run:a',
+        kind: 'approval', requiredAction: 'answer', prompt: 'Allow?',
+      }],
+    } } },
+    width: 80,
+  });
+  const calls = [];
+  const client = { async command(...args) { calls.push(args); return { phase: 'working' }; } };
+  await respondToVisualAttention(client, model, 0, 'allow');
+  assert.equal(calls[0][0], 'run.answer');
+  assert.deepEqual(calls[0][1], {
+    runId: 'run:a', requestId: 'request:a', answer: { decision: 'allow' },
+  });
+  await assert.rejects(respondToVisualAttention(client, { attention: [] }, 0, 'deny'),
+    (error) => error.code === 'visual_action_unavailable');
+});

--- a/impl/test/mcp-visualization.test.mjs
+++ b/impl/test/mcp-visualization.test.mjs
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ProductionConvergenceRuntime } from '../src/production-convergence.mjs';
+import { wrapProductionMcpServer } from '../src/production-mcp-complete.mjs';
+
+function rawServer() {
+  const story = {
+    narrative: () => 'The existing story compiler sees one worker making steady progress.',
+    signals: () => [],
+    memberStates: () => [{ workerId: 'worker:a', taskId: 'task:a', state: 'working' }],
+  };
+  return {
+    lifecycle: 'ready',
+    repoIds: new Set(['repo']),
+    principal: { userId: 'operator', sessionId: 'session:operator', capabilities: ['observe'], repoIds: ['repo'] },
+    maxWaitMs: 30_000,
+    toolDefinitions: [],
+    toolNames: new Set(),
+    _authority() { return null; },
+    _audit() {},
+    async takeToolQuota() { return { ok: true }; },
+    application: {
+      card() { return { schemaVersion: 1, repoId: 'repo', resident: { state: 'ready' } }; },
+      async command(name, args) {
+        if (name === 'deployment.doctor') return { ready: true, routes: [{ harness: 'codex', model: 'gpt-5.6-sol', effort: 'high', state: 'ready' }] };
+        if (name === 'run.inspect') return {
+          runId: args.runId, phase: 'working', objective: 'Visualize the fleet',
+          narrative: 'One worker is implementing the visual surface.',
+          workstreams: [{ workerId: 'worker:a', role: 'implementer', state: 'working', route: { harness: 'codex', model: 'gpt-5.6-sol', effort: 'high' } }],
+        };
+        if (name === 'run.follow') return { runId: args.runId, cursor: 4, events: [{ seq: 4, kind: 'verify.reverified', actor: 'baton', summary: 'Tests passed.' }] };
+        if (name === 'run.attention.watch') return { runId: args.runId, throughCursor: args.cursor, reasons: [] };
+        if (name === 'waves.progress') return { waveId: args.waveId, state: 'working' };
+        throw new Error(`unexpected command ${name}`);
+      },
+      async decisionList() { return { items: [] }; },
+    },
+    coordinator: {
+      _story: story,
+      list() { return [{ workerId: 'worker:a', state: 'working' }]; },
+      capabilityCards() { return []; },
+      readProviderStatus() { return { providers: [] }; },
+    },
+    async handle(message) {
+      if (message.method === 'initialize') return { jsonrpc: '2.0', id: message.id, result: { instructions: 'baton', capabilities: { tools: {} }, serverInfo: { name: 'baton', version: '0.1.0' } } };
+      if (message.method === 'tools/list') return { jsonrpc: '2.0', id: message.id, result: { tools: [] } };
+      return { jsonrpc: '2.0', id: message.id, result: { structuredContent: { ok: true } } };
+    },
+  };
+}
+
+test('MCP visualization is advertised and composes the existing snapshot/watch meta authorities', async () => {
+  const server = wrapProductionMcpServer(rawServer(), { runtime: new ProductionConvergenceRuntime() });
+  const listed = await server.handle({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+  assert.ok(listed.result.tools.some((tool) => tool.name === 'baton_surface_visualize'));
+  const response = await server.handle({
+    jsonrpc: '2.0', id: 2, method: 'tools/call',
+    params: { name: 'baton_surface_visualize', arguments: {
+      view: 'overview', runId: 'run:a', follow: true, width: 88,
+      afterCursor: 0, attentionCursor: 0, timeoutMs: 5,
+    } },
+  });
+  assert.equal(response.result.isError, undefined);
+  assert.equal(response.result.structuredContent.kind, 'baton.surface_visualization');
+  assert.equal(response.result.structuredContent.model.run.runId, 'run:a');
+  assert.equal(response.result.structuredContent.presentation.refresh.tool, 'baton_surface_visualize');
+  assert.match(response.result.content[0].text, /baton top/u);
+  assert.equal(response.result.content[0].text.includes('\u001b'), false);
+});
+
+test('MCP visualization rejects follow without a Run instead of inventing global watch authority', async () => {
+  const server = wrapProductionMcpServer(rawServer(), { runtime: new ProductionConvergenceRuntime() });
+  const response = await server.handle({
+    jsonrpc: '2.0', id: 3, method: 'tools/call',
+    params: { name: 'baton_surface_visualize', arguments: { follow: true } },
+  });
+  assert.equal(response.result.isError, true);
+  assert.equal(response.result.structuredContent.error.code, 'surface_visualization_invalid');
+});

--- a/impl/test/visual-model.test.mjs
+++ b/impl/test/visual-model.test.mjs
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { projectBatonVisualModel } from '../src/visual-model.mjs';
+
+function fixture() {
+  return {
+    snapshot: {
+      source: 'cli_authenticated_web',
+      doctor: { ok: true, value: {
+        ready: true,
+        deployment: { deploymentId: 'deployment:a', incarnation: 'incarnation:1' },
+        routes: [
+          { harness: 'codex', model: 'gpt-5.6-sol', effort: 'high', state: 'ready' },
+          { harness: 'kimi-code', model: 'kimi-code/k3', effort: 'high', state: 'blocked', summary: 'authentication_required' },
+        ],
+      } },
+      run: { ok: true, value: {
+        runId: 'run:a', phase: 'working', objective: 'Implement the visual surface',
+        narrative: 'Two workers are implementing and reviewing the visual surface.',
+        progress: { current: 'execute' },
+        attention: [{ id: 'request:approval', requestId: 'request:approval', kind: 'approval', requiredAction: 'answer', prompt: 'Allow the next effect?' }],
+        workstreams: [
+          { workerId: 'worker:alpha', role: 'implementer', state: 'working', task: { objective: 'Implement renderer' }, route: { harness: 'codex', model: 'gpt-5.6-sol', effort: 'high' }, budgetUsed: { tokens: 50 }, budget: { tokens: 100 }, pathScope: ['impl/src/**'] },
+          { workerId: 'worker:beta', role: 'reviewer', state: 'blocked', task: { objective: 'Review accessibility' }, route: { harness: 'kimi-code', model: 'kimi-code/k3', effort: 'high' }, warnings: ['approval_required'] },
+        ],
+      } },
+      convergence: { scheduler: { active: [{ lane: 'interactive_control' }], queued: { background_reconcile: 2 } } },
+      story: { narrative: 'The existing story compiler reports one active implementation and one blocked review.', signals: [{ type: 'blocked', worker: 'worker:beta' }] },
+    },
+    watch: {
+      source: 'cli_authenticated_web', runId: 'run:a', nextAfterCursor: 8, nextAttentionCursor: 3,
+      follow: { events: [
+        { seq: 7, kind: 'content.message', actor: 'worker', workerId: 'worker:alpha', message: '\u001b[31mI changed the renderer.\u001b[0m' },
+        { seq: 8, kind: 'verify.reverified', actor: 'baton', workerId: 'worker:alpha', summary: 'Focused renderer tests passed.' },
+      ] },
+      attention: { ok: true, value: { throughCursor: 3, reasons: [
+        { id: 'request:approval', requestId: 'request:approval', runId: 'run:a', kind: 'approval', requiredAction: 'answer', prompt: 'Allow the next effect?' },
+      ] } },
+    },
+  };
+}
+
+test('visual model composes existing Run, story, attention, telemetry and topology projections', () => {
+  const model = projectBatonVisualModel({ ...fixture(), width: 118, now: 1_700_000_000_000 });
+  assert.equal(model.kind, 'baton.visual_model');
+  assert.equal(model.run.runId, 'run:a');
+  assert.equal(model.story.source, 'story_compiler');
+  assert.equal(model.fleet.members.length, 2);
+  assert.equal(model.fleet.counts.active, 1);
+  assert.equal(model.attention.length, 1);
+  assert.equal(model.attention[0].respondable, true);
+  assert.equal(model.controls.approvals[0].allow.command, 'run.answer');
+  assert.equal(model.controls.takeover.available, false);
+  assert.ok(model.topology.edges.some((edge) => edge.relation === 'uses'));
+  assert.equal(model.telemetry.routes.length, 2);
+  assert.equal(model.cursors.after, 8);
+  assert.match(model.fingerprint, /^[a-f0-9]{64}$/u);
+});
+
+test('visual model keeps worker prose visibly untrusted and strips terminal control bytes', () => {
+  const model = projectBatonVisualModel({ ...fixture(), width: 90 });
+  const workerEvent = model.timeline.find((item) => item.actor === 'worker');
+  assert.equal(workerEvent.provenance, 'worker_prose');
+  assert.equal(workerEvent.summary, 'I changed the renderer.');
+  assert.equal(JSON.stringify(model).includes('\u001b'), false);
+  assert.equal(model.provenance.workerProse > 0, true);
+});
+
+test('visual model remains bounded and deterministic under oversized projection input', () => {
+  const data = fixture();
+  data.snapshot.run.value.workstreams = Array.from({ length: 100 }, (_, index) => ({
+    workerId: `worker:${String(index).padStart(3, '0')}`, state: 'working',
+  }));
+  data.watch.follow.events = Array.from({ length: 100 }, (_, index) => ({
+    seq: index + 1, kind: 'content.message', actor: 'worker', message: `event ${index}`,
+  }));
+  const left = projectBatonVisualModel({ ...data, width: 80, now: 1234 });
+  const right = projectBatonVisualModel({ ...data, width: 80, now: 1234 });
+  assert.equal(left.fleet.members.length, 64);
+  assert.equal(left.timeline.length, 64);
+  assert.equal(left.fingerprint, right.fingerprint);
+});

--- a/impl/test/visual-package-smoke.test.mjs
+++ b/impl/test/visual-package-smoke.test.mjs
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createVisualModel,
+  renderVisualFrame,
+} from '../src/visual-model.mjs';
+import {
+  parseBatonTopArgs,
+} from '../src/baton-top.mjs';
+
+test('visual package entrypoints remain importable without side effects', () => {
+  assert.equal(typeof createVisualModel, 'function');
+  assert.equal(typeof renderVisualFrame, 'function');
+  assert.equal(parseBatonTopArgs(['top', '--once']).kind, 'top');
+});

--- a/impl/test/visual-renderer.test.mjs
+++ b/impl/test/visual-renderer.test.mjs
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { projectBatonVisualModel } from '../src/visual-model.mjs';
+import { batonVisualWidth, createBatonMcpPresentation, renderBatonVisual } from '../src/visual-renderer.mjs';
+
+const snapshot = {
+  doctor: { ok: true, value: { ready: true, routes: [{ harness: 'codex', model: 'gpt-5.6-sol', effort: 'high', state: 'ready' }] } },
+  run: { ok: true, value: {
+    runId: 'run:render', phase: 'working', objective: 'Render responsive terminal feedback',
+    narrative: 'Flip is quietly keeping an eye on one active worker.', progress: { current: 'execute' },
+    workstreams: [{ workerId: 'worker:render', role: 'renderer', state: 'working', route: { harness: 'codex', model: 'gpt-5.6-sol', effort: 'high' } }],
+    attention: [{ id: 'request:1', requestId: 'request:1', runId: 'run:render', kind: 'approval', requiredAction: 'answer', prompt: 'Allow rendering?' }],
+  } },
+  convergence: { scheduler: { active: [{ lane: 'interactive_control' }], queued: { background_reconcile: 1 } } },
+};
+const watch = { follow: { events: [{ seq: 4, kind: 'content.message', actor: 'worker', workerId: 'worker:render', message: 'The layout is ready.' }] } };
+
+function model(width, view = 'overview') {
+  return projectBatonVisualModel({ snapshot, watch, width, view, now: 1_700_000_000_000 });
+}
+
+test('responsive renderer never exceeds the requested terminal width', () => {
+  for (const width of [40, 58, 84, 118, 160]) {
+    const output = renderBatonVisual(model(width), { width, color: false, motion: false });
+    for (const line of output.trimEnd().split('\n')) {
+      assert.ok(batonVisualWidth(line) <= width, `${width}: ${batonVisualWidth(line)} ${line}`);
+    }
+    assert.match(output, /baton top/u);
+    assert.match(output, /What is happening/u);
+  }
+});
+
+test('renderer provides distinct topology, timeline and telemetry views with provenance labels', () => {
+  const graph = renderBatonVisual(model(100, 'topology'), { width: 100, view: 'topology', motion: false });
+  const timeline = renderBatonVisual(model(100, 'timeline'), { width: 100, view: 'timeline', motion: false });
+  const telemetry = renderBatonVisual(model(100, 'telemetry'), { width: 100, view: 'telemetry', motion: false });
+  assert.match(graph, /Fleet graph/u);
+  assert.match(graph, /coordinates/u);
+  assert.match(timeline, /prose/u);
+  assert.match(timeline, /‹The layout is ready\.›/u);
+  assert.match(telemetry, /Route readiness/u);
+});
+
+test('MCP presentation carries static text, optional animation frames and refresh arguments', () => {
+  const value = model(96);
+  const presentation = createBatonMcpPresentation(value, { width: 96 });
+  assert.equal(presentation.kind, 'baton.visual_presentation');
+  assert.equal(presentation.animation.frames.length, 4);
+  assert.equal(presentation.refresh.tool, 'baton_surface_visualize');
+  assert.equal(presentation.refresh.arguments.runId, 'run:render');
+  assert.equal(presentation.refresh.arguments.follow, true);
+  assert.equal(presentation.text.includes('\u001b'), false);
+  assert.match(presentation.accessibleSummary, /Flip is quietly/u);
+});


### PR DESCRIPTION
## Scope

This PR implements the visualization commitments already present across Baton's telemetry, interaction-model, roadmap, frontier-feature, and full-system reports. It is an observability and presentation tranche over Baton's existing application, StoryCompiler, Run/Wave, attention, worker, route, provider-telemetry, CLI, Web, and MCP authorities—not a replacement dashboard runtime.

## What changed

### `baton top`

- Adds a dependency-free responsive TUI with compact, standard, and wide layouts.
- Uses the canonical Flip smile/thinking identity with subtle sparkle motion and restrained personality copy.
- Renders Run stage/progress, ensemble state, attention, provenance, bounded fleet relationships, route readiness, and controls from existing projections.
- Writes interactive frames only to the human terminal channel; stdout remains machine-clean.
- Automatically degrades to structured JSON when piped or non-interactive.
- Supports `--once`, `--json`, `--no-motion`, `--ascii`, `--run`, `--wave`, `--refresh`, and configured MCP operation.
- Restores raw mode, cursor visibility, and alternate-screen state on every exit path.

### MCP visual response

- Adds `baton_surface_visualize` to the unified MCP meta surface.
- Returns a bounded structured visual model in `structuredContent` and a static responsive terminal frame in text content.
- Returns refresh cursors and an explicit next invocation rather than claiming that a completed MCP response remains animated server-side.
- Retains existing MCP repository derivation, authorization, quota, audit, and application-command paths.

### Visual model and provenance

- Adds one bounded `baton.flip_visual_surface` model over existing snapshot/watch data.
- Distinguishes hub-derived facts from delimiter-wrapped untrusted provider prose.
- Projects Run→member→scope and Wave→Run edges only when those facts are present; absent relationships are not fabricated.
- Keeps all arrays, text, encoded response size, and rendered line widths bounded.
- Provides deterministic responsive rendering and reduced-motion/non-TTY behavior.

### Safe interaction

Interactive actions lower only to existing Baton commands:

- `run.approve`
- `run.answer`
- `run.stop`

Provider-session takeover is deliberately not implemented in presentation code. It remains unavailable until Baton exposes a separate, explicit, authorized takeover command.

## Existing work preserved

The implementation composes over:

- the existing deterministic `StoryCompiler` and Run narratives;
- authenticated resident Web snapshots and watches;
- unified surface capability resolution;
- existing MCP application/native capability inventory;
- existing attention and decision authorization;
- existing emergency-control and physical-reap semantics.

It does not add another ledger, scheduler, notification bus, task model, telemetry authority, or monitoring product. OpenTelemetry and external monitoring systems remain external; Baton owns only the story, fleet relationships, attention, provenance, and control context it can derive honestly.

## Documentation and packaging

- Adds the visual/TUI package exports.
- Documents `baton top`, MCP visualization, authority boundaries, responsive behavior, provenance, and reduced motion.
- Updates the report with an implementation-status matrix for every identified visualization concept.
- Extends packed-install smoke coverage to the visual exports and `baton top --help`.
- Keeps CI verification-only and adds the visual gate to the Node matrix.

## Validation

Developed red-first, then verified from `impl/` on the final working tree:

```bash
npm run test:visual
npm run test:unified-surfaces
npm run test:production-convergence
npm test
npm run test:contracts:validate
npm run test:surfaces
npm run test:contracts
npm run test:package
```

All commands exited successfully. The default `npm test` remains the complete historical suite, including the repository's red-first pins.